### PR TITLE
Github Runners migration part 1

### DIFF
--- a/.github/workflows/_build-contracts.yml
+++ b/.github/workflows/_build-contracts.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Generate, compile and lint contracts
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/_build-wasm-packages.yml
+++ b/.github/workflows/_build-wasm-packages.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Build wasm packages
-    runs-on: [self-hosted, Linux, X64, large]
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -68,5 +68,6 @@ jobs:
 
   measure-gas-usage-and-verifier-code-size:
     name: Measure gas usage
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/_measure-gas-and-contract-size.yml
     secrets: inherit


### PR DESCRIPTION
Use standard github runner (4 vCPU, 16 GB RAM) fro buidling wasm pkg and for contract compilation. This saves 3 minutes overall workflow run.
Before: https://github.com/Cardinal-Cryptography/blanksquare-monorepo/actions/runs/16672906315
After: https://github.com/Cardinal-Cryptography/blanksquare-monorepo/actions/runs/16674853053?pr=8

Also, small  bugfix so that when merge queue runs CI, it does not run one job which does not make sense in non-PR context.