### PR TITLE
Parallelize build wasm packages workflow

### DIFF
--- a/.github/workflows/_build-wasm-packages.yml
+++ b/.github/workflows/_build-wasm-packages.yml
@@ -19,6 +19,11 @@ on:
         required: true
         type: string
         default: 'crates/shielder_bindings/pkg'
+      upload-proving-keys:
+        description: 'Whether to upload the proving keys artifact'
+        required: false
+        type: boolean
+        default: true
 jobs:
   main:
     name: Build wasm packages
@@ -45,6 +50,7 @@ jobs:
           retention-days: 1
 
       - name: Upload generated proving keys to artifacts
+        if: ${{ inputs.upload-proving-keys }}
         uses: actions/upload-artifact@v4
         with:
           name: proving-keys-pkg

--- a/.github/workflows/_build-wasm-packages.yml
+++ b/.github/workflows/_build-wasm-packages.yml
@@ -3,14 +3,27 @@ name: Build wasm packages
 
 on:
   workflow_call:
-  workflow_dispatch:
-
+    inputs:
+      target:
+        description: 'Build target'
+        required: true
+        type: string
+        default: 'wasm'
+      artifact-name:
+        description: 'Wasm artifact name'
+        required: true
+        type: string
+        default: 'wasm-pkg'
+      artifact-path:
+        description: 'Path to wasm artifact'
+        required: true
+        type: string
+        default: 'crates/shielder_bindings/pkg'
 jobs:
   main:
     name: Build wasm packages
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -22,20 +35,13 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build shielder_bindings
-        run: cd crates/shielder_bindings && make wasm && make wasm-without-circuits
+        run: cd crates/shielder_bindings && make ${{ inputs.target }}
 
       - name: Upload generated wasm to artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wasm-pkg
-          path: crates/shielder_bindings/pkg
-          retention-days: 1
-
-      - name: Upload generated wasm without circuits to artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wasm-pkg-without-circuits
-          path: crates/shielder_bindings/pkg-without-circuits
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
           retention-days: 1
 
       - name: Upload generated proving keys to artifacts

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -40,15 +40,29 @@ jobs:
     uses: ./.github/workflows/_rust-crates-checks.yml
     secrets: inherit
 
-  build-wasm-packages:
-    name: Build wasm packages
+  build-wasm-package:
+    name: Build wasm package
     needs: [check-vars-and-secrets]
     uses: ./.github/workflows/_build-wasm-packages.yml
     secrets: inherit
+    with:
+      target: wasm
+      artifact-name: wasm-pkg
+      artifact-path: crates/shielder_bindings/pkg
+
+  build-wasm-package-without-circuits:
+    name: Build wasm package without circuits
+    needs: [check-vars-and-secrets]
+    uses: ./.github/workflows/_build-wasm-packages.yml
+    secrets: inherit
+    with:
+      target: wasm-without-circuits
+      artifact-name: wasm-pkg-without-circuits
+      artifact-path: crates/shielder_bindings/pkg-without-circuits
 
   ts-checks:
     name: Typescript modules checks
-    needs: [build-contracts, build-wasm-packages]
+    needs: [build-contracts, build-wasm-package, build-wasm-package-without-circuits]
     uses: ./.github/workflows/_ts-checks.yml
     secrets: inherit
 
@@ -57,7 +71,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ always() }}
     # dependencies should include all jobs, which interact with wasm artifact
-    needs: [build-wasm-packages, ts-checks]
+    needs: [build-wasm-package, build-wasm-package-without-circuits, ts-checks]
     steps:
       - uses: geekyeggo/delete-artifact@v5
         with:

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -49,6 +49,7 @@ jobs:
       target: wasm
       artifact-name: wasm-pkg
       artifact-path: crates/shielder_bindings/pkg
+      upload-proving-keys: true
 
   build-wasm-package-without-circuits:
     name: Build wasm package without circuits
@@ -59,6 +60,7 @@ jobs:
       target: wasm-without-circuits
       artifact-name: wasm-pkg-without-circuits
       artifact-path: crates/shielder_bindings/pkg-without-circuits
+      upload-proving-keys: false
 
   ts-checks:
     name: Typescript modules checks


### PR DESCRIPTION
This PR saves 2 minutes of overall CI time by parametrizing build wasm pkg workflow and calling it twice in parallel, once for normal wasm pkg and second time for wasm without circuits.

I removed `workflow_dispatch` trigger as it's not being used by the team members. 

This change requires changes in repo settings, and those are breaking changes - meaning that once this is merged, the other PRs must click "Update from latest branch".