### PR TITLE
Scheduler Service Setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -70,7 +70,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -300,7 +300,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash",
- "getrandom",
+ "getrandom 0.2.15",
  "hashbrown 0.15.2",
  "hex-literal",
  "indexmap 2.6.0",
@@ -309,7 +309,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "ruint",
  "rustc-hash 2.0.0",
  "serde",
@@ -436,7 +436,7 @@ dependencies = [
  "alloy-serde",
  "derive_more",
  "jsonwebtoken",
- "rand",
+ "rand 0.8.5",
  "serde",
  "strum 0.26.3",
 ]
@@ -498,7 +498,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand",
+ "rand 0.8.5",
  "thiserror 2.0.12",
 ]
 
@@ -717,8 +717,8 @@ dependencies = [
  "env_logger",
  "hex",
  "log",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rpassword",
  "rusqlite",
  "shielder-circuits",
@@ -849,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -859,7 +859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1021,12 +1021,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-nitro-enclaves-nsm-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92c1f4471b33f6a7af9ea421b249ed18a11c71156564baf6293148fa6ad1b09"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1072,6 +1110,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1129,6 +1178,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.104",
+ "which",
 ]
 
 [[package]]
@@ -1399,7 +1471,18 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1475,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 2.6.0",
 ]
 
 [[package]]
@@ -1487,6 +1570,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1528,6 +1622,15 @@ name = "clap_lex"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1730,7 +1833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1742,7 +1845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1988,7 +2091,7 @@ dependencies = [
  "hex",
  "hkdf",
  "k256",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "thiserror 2.0.12",
 ]
@@ -2012,7 +2115,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -2034,6 +2137,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -2171,7 +2294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2182,7 +2305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2241,6 +2364,12 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2387,8 +2516,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2431,7 +2572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2456,6 +2597,12 @@ dependencies = [
 
 [[package]]
 name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
@@ -2477,7 +2624,7 @@ dependencies = [
  "halo2curves",
  "hex",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "subtle",
  "uint",
 ]
@@ -2491,8 +2638,8 @@ dependencies = [
  "ff",
  "group",
  "halo2curves",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "rayon",
  "serde",
  "serde_derive",
@@ -2532,8 +2679,8 @@ dependencies = [
  "pairing",
  "pasta_curves",
  "paste",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "static_assertions",
  "subtle",
@@ -2630,7 +2777,7 @@ dependencies = [
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -2651,7 +2798,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -2858,7 +3005,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -3136,7 +3283,7 @@ dependencies = [
  "halo2_solidity_verifier",
  "hex",
  "powers-of-tau",
- "rand",
+ "rand 0.8.5",
  "rstest",
  "shielder-account",
  "shielder-circuits",
@@ -3146,12 +3293,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.8",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -3203,6 +3361,16 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -3271,10 +3439,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.166"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "libm"
@@ -3420,6 +3604,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,29 +3633,38 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6f8152da6d7892ff1b7a1c0fa3f435e92b5918ad67035c3bb432111d9a29b"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
 dependencies = [
  "base64 0.22.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
  "indexmap 2.6.0",
+ "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b482df36c13dd1869d73d14d28cd4855fbd6cfc32294bee109908a9f4a4ed7"
+checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.15.2",
  "metrics",
  "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
  "sketches-ddsketch",
 ]
 
@@ -3496,7 +3707,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -3508,7 +3719,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3536,6 +3747,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -3893,7 +4130,7 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -4066,7 +4303,7 @@ dependencies = [
  "halo2_proofs",
  "halo2curves",
  "num-bigint",
- "rand",
+ "rand 0.8.5",
  "shielder-circuits",
 ]
 
@@ -4077,6 +4314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4141,8 +4388,8 @@ dependencies = [
  "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -4180,7 +4427,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -4203,7 +4450,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.19",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4216,8 +4463,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "ring",
  "rustc-hash 2.0.0",
  "rustls 0.23.19",
@@ -4238,7 +4485,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4253,6 +4500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,9 +4518,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4277,7 +4540,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4286,7 +4559,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -4295,7 +4577,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4344,7 +4635,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -4548,7 +4839,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -4670,7 +4961,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "ruint-macro",
  "serde",
@@ -4753,7 +5044,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -4777,7 +5068,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4837,6 +5128,7 @@ version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4894,6 +5186,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4939,6 +5232,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "scheduler-common"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "base64 0.22.1",
+ "futures",
+ "serde",
+ "serde_json",
+ "shielder-relayer",
+ "shielder-setup",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tokio-vsock",
+]
+
+[[package]]
+name = "scheduler-server"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "axum",
+ "clap",
+ "enum-map",
+ "lazy_static",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "scheduler-common",
+ "serde",
+ "strum 0.27.2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-task-pool",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "vsock",
+]
+
+[[package]]
+name = "scheduler-tee"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "aws-nitro-enclaves-nsm-api",
+ "hex",
+ "log",
+ "powers-of-tau",
+ "rand 0.8.5",
+ "scheduler-common",
+ "serde",
+ "serde_json",
+ "shielder-circuits",
+ "shielder-setup",
+ "tokio",
+ "tokio-vsock",
+ "tracing-subscriber",
+ "type-conversions",
 ]
 
 [[package]]
@@ -5004,7 +5358,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "secp256k1-sys",
 ]
 
@@ -5087,6 +5441,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
 ]
 
 [[package]]
@@ -5259,7 +5632,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "halo2curves",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha3 0.10.8",
  "shielder-circuits",
@@ -5280,8 +5653,8 @@ dependencies = [
  "macros",
  "once_cell",
  "parameterized",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "regex",
  "static_assertions",
@@ -5333,7 +5706,7 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport",
  "halo2curves",
- "rand",
+ "rand 0.8.5",
  "shielder-setup",
  "thiserror 2.0.12",
  "tracing",
@@ -5359,7 +5732,7 @@ dependencies = [
  "openssl",
  "parameterized",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "rust_decimal",
  "serde",
@@ -5385,7 +5758,7 @@ name = "shielder-setup"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "rand",
+ "rand 0.8.5",
  "shielder-circuits",
 ]
 
@@ -5394,10 +5767,10 @@ name = "shielder_bindings"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "getrandom",
+ "getrandom 0.2.15",
  "halo2_proofs",
  "powers-of-tau",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "shielder-account",
  "shielder-circuits",
@@ -5452,7 +5825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5526,6 +5899,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5563,7 +5946,7 @@ dependencies = [
  "anyhow",
  "clap",
  "powers-of-tau",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "shielder-account",
  "shielder-circuits",
@@ -5616,6 +5999,9 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
 
 [[package]]
 name = "strum_macros"
@@ -5651,7 +6037,7 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
 ]
 
@@ -5899,7 +6285,7 @@ checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
  "once_cell",
  "pbkdf2",
- "rand",
+ "rand 0.8.5",
  "rustc-hash 1.1.0",
  "sha2",
  "thiserror 1.0.69",
@@ -5962,33 +6348,35 @@ dependencies = [
  "alloy-signer-local",
  "anyhow",
  "clap",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio 1.0.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6040,16 +6428,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.12"
+name = "tokio-task-pool"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "75b979d664a052ebb638f0eb4d1134bed9552a5975b82c0c61bf55ff27ff8953"
+dependencies = [
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-vsock"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1824fc0300433f400df6b6264a9ab00ba93f39d38c3157fb5f05183476c4af10"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
 ]
 
 [[package]]
@@ -6096,9 +6507,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -6166,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -6176,10 +6587,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term",
  "once_cell",
@@ -6546,6 +6958,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vsock"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
+dependencies = [
+ "libc",
+ "nix 0.29.0",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6578,6 +7000,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -6719,6 +7150,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -6962,6 +7405,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,9 @@ anyhow = { version = "1.0.86", default-features = false }
 askama = { version = "0.12.0", default-features = false }
 assert2 = { version = "0.3.15" }
 async-channel = { version = "2.3.1" }
+aws-nitro-enclaves-nsm-api = { version = "0.4.0" }
 axum = { version = "0.8.1" }
+base64 = { version = "0.22.1" }
 byteorder = { version = "1.4.3" }
 chacha20poly1305 = { version = "0.10.1", default-features = false }
 clap = { version = "4.5.8" }
@@ -37,6 +39,8 @@ darling = { version = "0.20.11" }
 ecies-encryption-cli = { git = "https://github.com/Cardinal-Cryptography/ecies-encryption-lib", tag = "v0.2.0" }
 # below dependency is also used in tee/Cargo.toml workspace
 ecies-encryption-lib = { git = "https://github.com/Cardinal-Cryptography/ecies-encryption-lib", tag = "v0.2.0" }
+enum-map = { version = "2.7.3" }
+futures = { version = "0.3.31" }
 getrandom = { version = "0.2" }
 halo2_poseidon = { git = "https://github.com/Cardinal-Cryptography/poseidon-gadget", rev = "ce317a6" }
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v0.3.0", default-features = false }
@@ -47,7 +51,7 @@ inquire = { version = "0.7.5" }
 itertools = { version = "0.13.0" }
 lazy_static = { version = "1.5.0" }
 metrics = { version = "0.24.1", default-features = false }
-metrics-exporter-prometheus = { version = "0.16.0", default-features = false }
+metrics-exporter-prometheus = { version = "0.17.2" }
 num-bigint = { version = "0.4.3" }
 once_cell = { version = "1.21.3" }
 openssl = { version = "0.10.59" }
@@ -84,10 +88,14 @@ syn = { version = "2.0.100" }
 testcontainers = { version = "0.19.0" }
 thiserror = { version = "2.0.12" }
 time = { version = "0.3.37" }
-tokio = { version = "1.38.0" }
-tower-http = { version = "0.6.1" }
+tokio = { version = "1.47.1" }
+tower-http = { version = "0.6.6" }
+tokio-task-pool = "0.1.5"
+tokio-util = "0.7.16"
+tokio-vsock = "0.7.1"
+vsock = "0.5.1"
 tracing = { version = "0.1.40" }
-tracing-subscriber = { version = "0.3.18" }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt", "chrono"] }
 uniffi = { version = "0.28.3" }
 utoipa = { version = "5.3.1" }
 utoipa-axum = { version = "0.2.0" }
@@ -116,3 +124,4 @@ shielder-relayer = { path = "crates/shielder-relayer" }
 shielder-setup = { path = "crates/shielder-setup" }
 type-conversions = { path = "crates/type-conversions" }
 transcript = { path = "crates/transcript" }
+scheduler-common = { path = "crates/scheduler-common" }

--- a/crates/scheduler-common/Cargo.toml
+++ b/crates/scheduler-common/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "scheduler-common"
+version = "0.1.0"
+edition = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+categories = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+alloy-primitives = { workspace = true, features = ["serde"] }
+base64 = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+shielder-setup = { workspace = true }
+shielder-relayer = { workspace = true }
+thiserror = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
+tokio-vsock = { workspace = true }
+tokio = { workspace = true }

--- a/crates/scheduler-common/Makefile
+++ b/crates/scheduler-common/Makefile
@@ -1,0 +1,7 @@
+.PHONY: format-rust
+format-rust: # Format all rust crates
+	cargo fmt --all -- --check
+
+.PHONY: lint-rust
+lint-rust: # Lint all rust crates
+	cargo clippy --release -- -D warnings

--- a/crates/scheduler-common/src/base64_serialization.rs
+++ b/crates/scheduler-common/src/base64_serialization.rs
@@ -1,0 +1,20 @@
+use base64::{engine::general_purpose, Engine as _};
+use serde::{Deserialize, Deserializer, Serializer};
+
+pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let s = general_purpose::STANDARD.encode(bytes);
+    serializer.serialize_str(&s)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    general_purpose::STANDARD
+        .decode(s.as_bytes())
+        .map_err(serde::de::Error::custom)
+}

--- a/crates/scheduler-common/src/lib.rs
+++ b/crates/scheduler-common/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod base64_serialization;
+pub mod protocol;
+pub mod vsock;

--- a/crates/scheduler-common/src/protocol.rs
+++ b/crates/scheduler-common/src/protocol.rs
@@ -1,0 +1,82 @@
+use alloy_primitives::{Address, Bytes, FixedBytes, U256};
+use serde::{Deserialize, Serialize};
+pub use shielder_relayer::RelayCalldata;
+use shielder_setup::consts::{ARITY, TREE_HEIGHT};
+
+use crate::{
+    base64_serialization,
+    vsock::{VsockClient, VsockServer},
+};
+
+pub const VSOCK_PORT: u16 = 5000;
+
+/// Payload for the `PrepareRelayCalldata` request.
+/// The payload is encrypted using the TEE Public Key.
+/// The TEE Public Key can be retrieved using the `TeePublicKey` request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Payload {
+    pub account_id: U256,
+    pub account_old_balance: U256,
+    pub nullfier_old: U256,
+    pub nullfier_new: U256,
+    pub last_note_index: U256,
+
+    pub mac_salt: U256,
+    pub contract_version: FixedBytes<3>,
+    pub chain_id: U256,
+    pub token_address: Address,
+    /// Total amount to be withdrawn. This amount includes fees (protocol and relayer fees).
+    pub withdrawal_value: U256,
+    pub withdraw_address: Address,
+    pub pocket_money: U256,
+    pub protocol_fee: U256,
+    pub memo: Bytes,
+
+    /// Maximum relayer fee.
+    pub max_relayer_fee: U256,
+    /// Timestamp after which the transaction can be relayed to chain.
+    pub relay_after: U256,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Request {
+    /// Message used to determine if TEE server is healthy
+    Ping,
+
+    /// Retrieves TEE Public Key, ie key which is used by the user to encrypt inputs to a circuit
+    TeePublicKey,
+
+    /// Request to prepare calldata for a relay transaction.
+    PrepareRelayCalldata {
+        /// Encrypted payload, see [`Payload`].
+        /// It is encrypted using TEE Public Key.
+        #[serde(with = "base64_serialization")]
+        payload: Vec<u8>,
+        /// Relayer fee
+        relayer_fee: U256,
+        /// Address of the relayer which will receive the relayer fee
+        relayer_address: Address,
+        /// Current merkle path
+        merkle_path: Box<[[U256; ARITY]; TREE_HEIGHT]>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Response {
+    /// Response to a health check,
+    Pong,
+
+    /// TEE Server public key, used to encrypt payload sent in [`Request::PrepareRelayCalldata`]
+    TeePublicKey {
+        public_key: String,
+        #[serde(with = "base64_serialization")]
+        attestation_document: Vec<u8>,
+    },
+
+    /// Response to [`Request::PrepareRelayCalldata`].
+    /// Contains calldata that can be used to relay the transaction to the chain.
+    PrepareRelayCalldata { calldata: RelayCalldata },
+}
+
+pub type SchedulerServer = VsockServer<Request, Response>;
+pub type SchedulerClient = VsockClient<Request, Response>;

--- a/crates/scheduler-common/src/vsock.rs
+++ b/crates/scheduler-common/src/vsock.rs
@@ -1,0 +1,103 @@
+use std::marker::PhantomData;
+
+use futures::{SinkExt as _, StreamExt as _};
+use serde::{Deserialize, Serialize};
+use serde_json::Deserializer;
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+use tokio_vsock::{OwnedReadHalf, OwnedWriteHalf, VsockAddr, VsockStream};
+
+#[derive(thiserror::Error, Debug)]
+pub enum VsockError {
+    #[error("IO error: {0}")]
+    IO(#[from] std::io::Error),
+
+    #[error("Serde error: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    #[error("Protocol error: {0}")]
+    Protocol(String),
+
+    #[error("Connection closed")]
+    Closed,
+}
+
+pub struct VsockClient<Req, Resp> {
+    vsock: Vsock,
+    _marker: PhantomData<(Req, Resp)>,
+}
+
+impl<'de, Req: Serialize, Resp: Deserialize<'de>> VsockClient<Req, Resp> {
+    pub async fn new(cid: u32, port: u32) -> Result<Self, VsockError> {
+        Ok(Self {
+            vsock: Vsock::new(cid, port).await?,
+            _marker: PhantomData,
+        })
+    }
+
+    pub async fn request(&mut self, request: &Req) -> Result<Resp, VsockError> {
+        self.vsock.send(request).await?;
+        self.vsock.recv().await
+    }
+}
+
+pub struct VsockServer<Req, Resp> {
+    vsock: Vsock,
+    _marker: PhantomData<(Req, Resp)>,
+}
+
+impl<'de, Req: Deserialize<'de>, Resp: Serialize> VsockServer<Req, Resp> {
+    pub async fn handle_request<F: FnOnce(Req) -> Result<Resp, VsockError>>(
+        &mut self,
+        handler: F,
+    ) -> Result<(), VsockError> {
+        let req = self.vsock.recv().await?;
+        let res = handler(req)?;
+        self.vsock.send(&res).await?;
+        Ok(())
+    }
+}
+
+impl<Req, Resp> From<VsockStream> for VsockServer<Req, Resp> {
+    fn from(value: VsockStream) -> Self {
+        Self {
+            vsock: value.into(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+struct Vsock {
+    read: FramedRead<OwnedReadHalf, LengthDelimitedCodec>,
+    write: FramedWrite<OwnedWriteHalf, LengthDelimitedCodec>,
+}
+
+impl From<VsockStream> for Vsock {
+    fn from(connection: VsockStream) -> Self {
+        let (read, write) = connection.into_split();
+        let write = FramedWrite::new(write, LengthDelimitedCodec::new());
+        let read = FramedRead::new(read, LengthDelimitedCodec::new());
+
+        Self { write, read }
+    }
+}
+
+impl Vsock {
+    pub async fn new(cid: u32, port: u32) -> Result<Self, VsockError> {
+        let connection = VsockStream::connect(VsockAddr::new(cid, port)).await?;
+        Ok(connection.into())
+    }
+
+    pub async fn send<T: Serialize>(&mut self, msg: &T) -> Result<(), VsockError> {
+        let msg = serde_json::to_vec(msg)?;
+        self.write.send(msg.into()).await?;
+        Ok(())
+    }
+
+    pub async fn recv<'de, T: Deserialize<'de>>(&mut self) -> Result<T, VsockError> {
+        let msg = &self.read.next().await.ok_or(VsockError::Closed)??;
+        let mut de = Deserializer::from_reader(msg.as_ref());
+        let res = T::deserialize(&mut de)?;
+
+        Ok(res)
+    }
+}

--- a/crates/scheduler-server/Cargo.toml
+++ b/crates/scheduler-server/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "scheduler-server"
+version = "0.1.0"
+edition = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+categories = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+alloy-primitives = { workspace = true, features = ["serde"] }
+axum = { workspace = true, features = ["tokio", "macros"] }
+clap = { workspace = true, features = ["derive", "env"] }
+enum-map = { workspace = true }
+lazy_static = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+serde = { workspace = true }
+scheduler-common = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["net", "rt", "rt-multi-thread"] }
+tokio-task-pool = { workspace = true, features = ["log"] }
+tower-http = { workspace = true, features = ["cors"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+vsock = { workspace = true }

--- a/crates/scheduler-server/Makefile
+++ b/crates/scheduler-server/Makefile
@@ -1,0 +1,10 @@
+.PHONY: format-rust
+format-rust: # Format all rust crates
+	cargo fmt --all -- --check
+
+.PHONY: lint-rust
+lint-rust: # Lint all rust crates
+	cargo clippy --release -- -D warnings
+
+run:
+	RUST_LOG=info cargo run --release

--- a/crates/scheduler-server/src/command_line_args.rs
+++ b/crates/scheduler-server/src/command_line_args.rs
@@ -1,0 +1,52 @@
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+pub struct CommandLineArgs {
+    /// A port on which this server listens to incoming HTTP connections.
+    #[arg(short, long, default_value = "3000", env = "PUBLIC_PORT")]
+    pub public_port: u16,
+
+    /// A port on which this server exposes its metrics endpoint.
+    #[arg(short, long, default_value = "3001", env = "METRICS_PORT")]
+    pub metrics_port: u16,
+
+    /// Internal port on which host and tee applications talks to each other
+    /// This is the part of the vsock endpoint, which is tee_cid:tee_port
+    #[arg(short, long, default_value_t = scheduler_common::protocol::VSOCK_PORT, env = "TEE_PORT")]
+    pub tee_port: u16,
+
+    /// Local IPv4 address on which this server listens to incoming HTTP connections
+    #[arg(short, long, default_value = "0.0.0.0", env = "BIND_ADDRESS")]
+    pub bind_address: String,
+
+    /// A context identifier on which this server and TEE server communicate with each other
+    /// This is the part of the vsock endpoint, which is tee_cid:tee_port
+    #[clap(long, default_value_t = vsock::VMADDR_CID_HOST, env = "TEE_CID")]
+    pub tee_cid: u32,
+
+    /// How many incoming requests can this server handle at once
+    /// Do not raise it above 128 as this is the limit of vsock connections, at least
+    /// for the rust lib used by this server
+    #[clap(long, default_value_t = 100, env = "TASK_POOL_CAPACITY")]
+    pub task_pool_capacity: usize,
+
+    /// Maximum request size (in bytes) sent to server
+    #[clap(long, default_value_t = 100 * 1024, env = "MAXIMUM_REQUEST_SIZE")]
+    pub maximum_request_size: usize,
+
+    /// How much time this server waits for a task pool to spawn a new task
+    #[clap(long, default_value_t = 5, env = "TASK_POOL_TIMEOUT_SECS")]
+    pub task_pool_timeout_secs: u64,
+
+    /// How much time this server waits for a response from TEE
+    #[clap(long, default_value_t = 60, env = "TEE_COMPUTE_TIMEOUT_SECS")]
+    pub tee_compute_timeout_secs: u64,
+
+    /// How often to perform metric upkeep
+    #[clap(long, default_value_t = 60, env = "METRICS_UPKEEP_TIMEOUT_SECS")]
+    pub(crate) metrics_upkeep_timeout_secs: u64,
+
+    /// How long are the buckets from which metric histograms are built
+    #[clap(long, default_value_t = 60, env = "METRICS_BUCKET_DURATION_SECS")]
+    pub(crate) metrics_bucket_duration_secs: u64,
+}

--- a/crates/scheduler-server/src/error.rs
+++ b/crates/scheduler-server/src/error.rs
@@ -1,0 +1,43 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response as AxumResponse},
+};
+use scheduler_common::vsock::VsockError;
+use tokio::task::JoinError;
+use tracing::error;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SchedulerServerError {
+    #[error("Internal I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Task pool error: {0}")]
+    TaskPool(#[from] tokio_task_pool::Error),
+
+    #[error("Join handle error: {0}")]
+    JoinHandleError(#[from] JoinError),
+
+    #[error("Proving Server error: {0}")]
+    ProvingServerError(#[from] VsockError),
+
+    #[error("Failed to initialize metrics: {0}")]
+    MetricsError(#[from] metrics_exporter_prometheus::BuildError),
+
+    #[error("Failed to parse commandline arguments: {0}")]
+    ParseError(String),
+}
+
+impl IntoResponse for SchedulerServerError {
+    fn into_response(self) -> AxumResponse {
+        let (status, error_message) = match &self {
+            SchedulerServerError::TaskPool(_) => {
+                (StatusCode::SERVICE_UNAVAILABLE, "Try again later")
+            }
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error"),
+        };
+
+        error!("Error encountered: {:?}", self);
+
+        (status, error_message).into_response()
+    }
+}

--- a/crates/scheduler-server/src/handlers/health.rs
+++ b/crates/scheduler-server/src/handlers/health.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+
+use axum::{extract::State, Json};
+use scheduler_common::protocol::{Request, Response};
+use tracing::instrument;
+
+use crate::{error::SchedulerServerError, handlers::request, AppState};
+
+#[instrument(level = "info")]
+pub async fn health(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Response>, SchedulerServerError> {
+    let task_pool = state.task_pool.clone();
+
+    task_pool
+        .spawn(async move { request(state, Request::Ping).await })
+        .await
+        .map_err(SchedulerServerError::TaskPool)?
+        .await
+        .map_err(SchedulerServerError::JoinHandleError)??
+        .map_err(SchedulerServerError::ProvingServerError)
+}

--- a/crates/scheduler-server/src/handlers/metrics.rs
+++ b/crates/scheduler-server/src/handlers/metrics.rs
@@ -1,0 +1,158 @@
+use enum_map::{enum_map, Enum, EnumMap};
+use lazy_static::lazy_static;
+use metrics::{histogram, Histogram};
+use strum::{EnumIter, EnumString, IntoEnumIterator as _, IntoStaticStr};
+use tokio::time::Instant;
+use tracing::{
+    span::{Attributes, Id},
+    Subscriber,
+};
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+lazy_static! {
+    static ref BUSY_HISTOGRAMS: EnumMap<FutureTimingMetric, Histogram> = enum_map! {
+        FutureTimingMetric::BuildingVsocksConnection => histogram!(format!("{}_busy", <&str>::from(FutureTimingMetric::BuildingVsocksConnection))),
+        FutureTimingMetric::SendingTeeRequest => histogram!(format!("{}_busy", <&str>::from(FutureTimingMetric::SendingTeeRequest))),
+        FutureTimingMetric::Health => histogram!(format!("{}_busy", <&str>::from(FutureTimingMetric::Health))),
+        FutureTimingMetric::GenerateProof => histogram!(format!("{}_busy", <&str>::from(FutureTimingMetric::GenerateProof))),
+        FutureTimingMetric::TeePublicKey => histogram!(format!("{}_busy", <&str>::from(FutureTimingMetric::TeePublicKey))),
+    };
+    static ref IDLE_HISTOGRAMS: EnumMap<FutureTimingMetric, Histogram> = enum_map! {
+        FutureTimingMetric::BuildingVsocksConnection => histogram!(format!("{}_idle", <&str>::from(FutureTimingMetric::BuildingVsocksConnection))),
+        FutureTimingMetric::SendingTeeRequest => histogram!(format!("{}_idle", <&str>::from(FutureTimingMetric::SendingTeeRequest))),
+        FutureTimingMetric::Health => histogram!(format!("{}_idle", <&str>::from(FutureTimingMetric::Health))),
+        FutureTimingMetric::GenerateProof => histogram!(format!("{}_idle", <&str>::from(FutureTimingMetric::GenerateProof))),
+        FutureTimingMetric::TeePublicKey => histogram!(format!("{}_idle", <&str>::from(FutureTimingMetric::TeePublicKey))),
+    };
+}
+
+#[derive(Debug, Clone, Copy, EnumIter, EnumString, IntoStaticStr, Enum)]
+pub enum FutureTimingMetric {
+    #[strum(serialize = "Building_VSOCK_connection")]
+    BuildingVsocksConnection,
+    #[strum(serialize = "Sending_TEE_request")]
+    SendingTeeRequest,
+    #[strum(serialize = "health")]
+    Health,
+    #[strum(serialize = "generate_proof")]
+    GenerateProof,
+    #[strum(serialize = "tee_public_key")]
+    TeePublicKey,
+}
+
+impl FutureTimingMetric {
+    pub fn by_name(name: &str) -> Option<Self> {
+        name.parse().ok()
+    }
+
+    pub const fn name(&self) -> &'static str {
+        match self {
+            FutureTimingMetric::BuildingVsocksConnection => "Building_VSOCK_connection",
+            FutureTimingMetric::SendingTeeRequest => "Sending_TEE_request",
+            FutureTimingMetric::Health => "health",
+            FutureTimingMetric::GenerateProof => "generate_proof",
+            FutureTimingMetric::TeePublicKey => "tee_public_key",
+        }
+    }
+
+    pub fn busy_histogram(&self) -> &'static Histogram {
+        &BUSY_HISTOGRAMS[*self]
+    }
+
+    pub fn idle_histogram_name(&self) -> &'static Histogram {
+        &IDLE_HISTOGRAMS[*self]
+    }
+}
+
+/// A tracing_subscriber layer that collects timing metrics for spans.
+///
+/// Based on tracing_subscriber::fmt. Handles spans that are entered and exited
+/// multiple times, which is needed to track the time spent in busy and idle states
+/// for asynchronous operations.
+///
+/// The metrics are submitted to the metrics crate as histograms.
+#[derive(Debug, Clone)]
+pub struct FutureHistogramLayer;
+
+struct Timings {
+    idle: u64,
+    busy: u64,
+    last: Instant,
+}
+
+impl Timings {
+    fn new() -> Self {
+        Self {
+            idle: 0,
+            busy: 0,
+            last: Instant::now(),
+        }
+    }
+}
+
+impl<S> Layer<S> for FutureHistogramLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        if FutureTimingMetric::iter().any(|metric| metadata.name() == metric.name()) {
+            tracing::subscriber::Interest::always()
+        } else {
+            tracing::subscriber::Interest::never()
+        }
+    }
+
+    fn on_new_span(&self, _: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if extensions.get_mut::<Timings>().is_none() {
+            extensions.insert(Timings::new());
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+        if let Some(timings) = extensions.get_mut::<Timings>() {
+            let now = Instant::now();
+            timings.idle += (now - timings.last).as_micros() as u64;
+            timings.last = now;
+        }
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+        if let Some(timings) = extensions.get_mut::<Timings>() {
+            let now = Instant::now();
+            timings.busy += (now - timings.last).as_micros() as u64;
+            timings.last = now;
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let span = ctx.span(&id).expect("Span not found, this is a bug");
+        let extensions = span.extensions();
+        if let Some(timing) = extensions.get::<Timings>() {
+            let Timings {
+                busy,
+                mut idle,
+                last,
+            } = *timing;
+            idle += (Instant::now() - last).as_micros() as u64;
+
+            let metric =
+                FutureTimingMetric::by_name(span.metadata().name()).expect("Invalid metric name");
+            metric.busy_histogram().record(micros_to_secs(busy));
+            metric.idle_histogram_name().record(micros_to_secs(idle));
+        }
+    }
+}
+
+fn micros_to_secs(micros: u64) -> f64 {
+    micros as f64 / 1_000_000.0
+}

--- a/crates/scheduler-server/src/handlers/schedule_withdraw.rs
+++ b/crates/scheduler-server/src/handlers/schedule_withdraw.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use alloy_primitives::U256;
+use axum::{extract::State, response::IntoResponse, Json};
+use scheduler_common::base64_serialization;
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+
+/// When requesting a withdraw schedule, user sends this struct as a JSON
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ScheduleWithdrawRequest {
+    /// For `payload` schema, see [`scheduler_common::protocol::Payload`].
+    #[serde(with = "base64_serialization")]
+    payload: Vec<u8>,
+
+    // Unecrypted data useful for basic checks.
+    // It should be consistent with the data in `payload`.
+    // TBD what exactly is needed
+    /// Index of the last leaf in the Merkle tree containing the account's note.
+    /// Necessary to get the merkle path from this leaf to the current root.
+    last_note_index: U256,
+    /// Maximum fee that the relayer can charge for this transaction.
+    max_relayer_fee: U256,
+    /// Timestamp after which the relay is allowed.
+    relay_after: U256,
+}
+
+pub async fn schedule_withdraw(
+    State(_state): State<Arc<AppState>>,
+    Json(_schedule_withdraw_request): Json<ScheduleWithdrawRequest>,
+) -> impl IntoResponse {
+    (
+        axum::http::StatusCode::NOT_IMPLEMENTED,
+        "Not implemented yet",
+    )
+}

--- a/crates/scheduler-server/src/handlers/tee_public_key.rs
+++ b/crates/scheduler-server/src/handlers/tee_public_key.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+
+use axum::{extract::State, Json};
+use scheduler_common::protocol::{Request, Response};
+use tracing::instrument;
+
+use crate::{error::SchedulerServerError, handlers::request, AppState};
+
+#[instrument(level = "info")]
+pub async fn tee_public_key(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Response>, SchedulerServerError> {
+    let task_pool = state.task_pool.clone();
+
+    task_pool
+        .spawn(async move { request(state, Request::TeePublicKey).await })
+        .await
+        .map_err(SchedulerServerError::TaskPool)?
+        .await
+        .map_err(SchedulerServerError::JoinHandleError)??
+        .map_err(SchedulerServerError::ProvingServerError)
+}

--- a/crates/scheduler-server/src/main.rs
+++ b/crates/scheduler-server/src/main.rs
@@ -1,0 +1,82 @@
+mod command_line_args;
+mod error;
+mod handlers;
+
+use std::{net::SocketAddrV4, sync::Arc, time::Duration};
+
+use axum::{
+    extract::DefaultBodyLimit,
+    routing::{get, post},
+    serve, Router,
+};
+use clap::Parser;
+use error::SchedulerServerError as Error;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tokio::net::TcpListener;
+use tower_http::cors::CorsLayer;
+use tracing::info;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+use crate::{
+    command_line_args::CommandLineArgs,
+    handlers::{self as server_handlers, metrics::FutureHistogramLayer},
+};
+
+#[derive(Debug)]
+struct AppState {
+    options: CommandLineArgs,
+    task_pool: Arc<tokio_task_pool::Pool>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(
+            fmt::layer()
+                .with_ansi(true)
+                .with_timer(fmt::time::ChronoUtc::new("%Y-%m-%dT%H:%M:%S%.3fZ".into()))
+                .with_span_events(fmt::format::FmtSpan::CLOSE),
+        )
+        .with(FutureHistogramLayer)
+        .init();
+
+    let options = CommandLineArgs::parse();
+
+    PrometheusBuilder::new()
+        .with_http_listener(SocketAddrV4::new(
+            options
+                .bind_address
+                .parse()
+                .map_err(|_| Error::ParseError("Invalid bind address".to_string()))?,
+            options.metrics_port,
+        ))
+        .set_bucket_duration(Duration::from_secs(options.metrics_bucket_duration_secs))?
+        .upkeep_timeout(Duration::from_secs(options.metrics_upkeep_timeout_secs))
+        .install()?;
+
+    let listener = TcpListener::bind((options.bind_address.clone(), options.public_port)).await?;
+    let task_pool = tokio_task_pool::Pool::bounded(options.task_pool_capacity)
+        .with_spawn_timeout(Duration::from_secs(options.task_pool_timeout_secs))
+        .with_run_timeout(Duration::from_secs(options.tee_compute_timeout_secs))
+        .into();
+
+    let app = Router::new()
+        .route("/health", get(server_handlers::health::health))
+        .route(
+            "/public_key",
+            get(server_handlers::tee_public_key::tee_public_key),
+        )
+        .route(
+            "/schedule_withdraw",
+            post(server_handlers::schedule_withdraw::schedule_withdraw),
+        )
+        .layer(DefaultBodyLimit::max(options.maximum_request_size))
+        .layer(CorsLayer::permissive())
+        .with_state(AppState { options, task_pool }.into());
+
+    info!("Starting local server on {}", listener.local_addr()?);
+    serve(listener, app).await?;
+
+    Ok(())
+}

--- a/crates/scheduler-tee/Cargo.toml
+++ b/crates/scheduler-tee/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "scheduler-tee"
+version = "0.1.0"
+edition = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+categories = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+alloy-primitives = { workspace = true, features = ["serde"] }
+aws-nitro-enclaves-nsm-api = { workspace = true, optional = true }
+hex = { workspace = true }
+log = { workspace = true }
+scheduler-common = { workspace = true }
+tokio = { workspace = true, features = [
+    "rt",
+    "rt-multi-thread",
+    "macros",
+    "time",
+] }
+tokio-vsock = { workspace = true }
+shielder-circuits = { workspace = true }
+shielder-setup = { workspace = true }
+rand = { workspace = true }
+type-conversions = { workspace = true }
+tracing-subscriber = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[build-dependencies]
+powers-of-tau = { workspace = true }
+rand = { workspace = true, features = ["small_rng"] }
+shielder-circuits = { workspace = true }
+
+[features]
+default = ["dep:aws-nitro-enclaves-nsm-api"]
+# if enabled, TEE server does not query /dev/nsm driver, so enable this feature for local tests
+without_attestation = []

--- a/crates/scheduler-tee/Makefile
+++ b/crates/scheduler-tee/Makefile
@@ -1,0 +1,10 @@
+.PHONY: format-rust
+format-rust: # Format all rust crates
+	cargo fmt --all -- --check
+
+.PHONY: lint-rust
+lint-rust: # Lint all rust crates
+	cargo clippy --release -- -D warnings
+
+run-without-attestation:
+	RUST_LOG=info cargo run --release --features without_attestation

--- a/crates/scheduler-tee/build.rs
+++ b/crates/scheduler-tee/build.rs
@@ -1,0 +1,45 @@
+//! This file has been copied from crates/shielder_bindings/build.rs
+
+//! This script builds artifacts, which are later
+//! embedded into the wasm binary.
+//! To speedup the build process, we cache the artifacts after the first build.
+//!
+//! When working locally, the `artifacts/` directory should be cleaned after the circuits are changed.
+use powers_of_tau::{get_ptau_file_path, read as read_setup_parameters, Format};
+use shielder_circuits::{
+    circuits::Params,
+    generate_keys_with_min_k,
+    marshall::{marshall_params, marshall_pk},
+    withdraw::WithdrawCircuit,
+    Circuit, Fr, MAX_K,
+};
+
+/// This function is used to generate the artifacts for the circuit, i.e. hardcoded keys
+/// and parameters. Saves results to `params.bin` and `pk.bin`.
+fn gen_params_pk<C: Circuit<Fr> + Default>(circuit_name: &str, full_params: &Params) {
+    std::fs::create_dir_all(format!("artifacts/{circuit_name}"))
+        .expect("Failed to create directory");
+    let (params, k, pk, _) = generate_keys_with_min_k(C::default(), full_params.clone())
+        .expect("keys should not fail to generate");
+    let params_bytes = marshall_params(&params).expect("Failed to marshall params");
+    std::fs::write(format!("artifacts/{circuit_name}/params.bin"), params_bytes)
+        .expect("Failed to write params.bin");
+    let key_bytes = marshall_pk(k, &pk);
+    std::fs::write(format!("artifacts/{circuit_name}/pk.bin"), key_bytes)
+        .expect("Failed to write pk.bin");
+}
+
+/// This function is used to generate the artifacts for the WithdrawCircuit
+fn generate_withdraw(full_params: &Params) {
+    gen_params_pk::<WithdrawCircuit>("withdraw", full_params);
+}
+
+fn main() {
+    let full_params = read_setup_parameters(
+        get_ptau_file_path(MAX_K, Format::PerpetualPowersOfTau),
+        Format::PerpetualPowersOfTau,
+    )
+    .expect("failed to read parameters from the ptau file");
+
+    generate_withdraw(&full_params);
+}

--- a/crates/scheduler-tee/src/main.rs
+++ b/crates/scheduler-tee/src/main.rs
@@ -1,0 +1,20 @@
+mod server;
+use log::info;
+use scheduler_common::{protocol::VSOCK_PORT, vsock::VsockError};
+
+#[tokio::main]
+async fn main() -> Result<(), VsockError> {
+    tracing_subscriber::fmt::init();
+
+    let server = server::Server::new(VSOCK_PORT)?;
+    info!("Server listening on: {:?}", server.local_addr()?);
+
+    loop {
+        let (stream, _) = server.listener().accept().await?;
+
+        let server_clone = server.clone();
+        tokio::spawn(async move {
+            server_clone.handle_client(stream).await;
+        });
+    }
+}

--- a/crates/scheduler-tee/src/server.rs
+++ b/crates/scheduler-tee/src/server.rs
@@ -1,0 +1,160 @@
+use std::sync::Arc;
+
+use alloy_primitives::{Address, U256};
+#[cfg(not(feature = "without_attestation"))]
+use aws_nitro_enclaves_nsm_api::{
+    api::Request as NsmRequest,
+    api::Response as NsmResponse,
+    driver::{nsm_exit, nsm_init, nsm_process_request},
+};
+use log::{debug, info};
+use scheduler_common::{
+    protocol::{Payload, Request, Response, SchedulerServer},
+    vsock::VsockError,
+};
+use shielder_setup::consts::{ARITY, TREE_HEIGHT};
+use tokio_vsock::{VsockAddr, VsockListener, VsockStream, VMADDR_CID_ANY};
+
+pub struct Server {
+    #[cfg(not(feature = "without_attestation"))]
+    nsm_fd: i32,
+
+    listener: VsockListener,
+}
+
+impl Server {
+    pub fn new(port: u16) -> Result<Arc<Self>, VsockError> {
+        let address = VsockAddr::new(VMADDR_CID_ANY, port as u32);
+        let listener = VsockListener::bind(address)?;
+
+        #[cfg(not(feature = "without_attestation"))]
+        let nsm_fd = Self::init_nsm_driver()?;
+
+        #[cfg(feature = "without_attestation")]
+        info!("Running server without attestation (TEST BUILD).");
+
+        Ok(Arc::new(Self {
+            listener,
+
+            #[cfg(not(feature = "without_attestation"))]
+            nsm_fd,
+        }))
+    }
+
+    pub fn local_addr(&self) -> Result<VsockAddr, VsockError> {
+        Ok(self.listener.local_addr()?)
+    }
+
+    pub fn listener(&self) -> &VsockListener {
+        &self.listener
+    }
+
+    pub fn public_key(&self) -> Vec<u8> {
+        todo!("Implement public key retrieval logic here");
+    }
+
+    pub async fn handle_client(self: Arc<Self>, stream: VsockStream) {
+        let result = self.do_handle_client(stream).await;
+        debug!("Client disconnected: {result:?}");
+    }
+
+    async fn do_handle_client(&self, stream: VsockStream) -> Result<(), VsockError> {
+        let mut server: SchedulerServer = stream.into();
+
+        loop {
+            server
+                .handle_request(|request| match request {
+                    Request::Ping => Ok(Response::Pong),
+                    Request::TeePublicKey => self.public_key_response(),
+                    Request::PrepareRelayCalldata {
+                        payload,
+                        relayer_address,
+                        relayer_fee,
+                        merkle_path,
+                    } => self.generate_proof_response(
+                        payload,
+                        relayer_address,
+                        relayer_fee,
+                        merkle_path,
+                    ),
+                })
+                .await?;
+        }
+    }
+
+    fn public_key_response(&self) -> Result<Response, VsockError> {
+        let public_key = self.public_key();
+        let public_key_hex = hex::encode(&public_key);
+
+        #[cfg(not(feature = "without_attestation"))]
+        let attestation_document = self.request_attestation_from_nsm_driver(public_key)?;
+
+        #[cfg(feature = "without_attestation")]
+        let attestation_document = Vec::new();
+
+        Ok(Response::TeePublicKey {
+            public_key: public_key_hex,
+            attestation_document,
+        })
+    }
+
+    fn generate_proof_response(
+        &self,
+        payload: Vec<u8>,
+        _relayer_address: Address,
+        _relayer_fee: U256,
+        _merkle_path: Box<[[U256; ARITY]; TREE_HEIGHT]>,
+    ) -> Result<Response, VsockError> {
+        let decrypted_payload = self.decrypt_payload(&payload)?;
+
+        let _deserialized_payload: Payload = serde_json::from_slice(&decrypted_payload)?;
+
+        todo!("Implement proof generation logic here");
+    }
+
+    fn decrypt_payload(&self, _payload: &[u8]) -> Result<Vec<u8>, VsockError> {
+        todo!("Implement decryption logic here");
+    }
+
+    #[cfg(not(feature = "without_attestation"))]
+    fn request_attestation_from_nsm_driver(
+        &self,
+        tee_public_key: Vec<u8>,
+    ) -> Result<Vec<u8>, VsockError> {
+        match nsm_process_request(
+            self.nsm_fd,
+            NsmRequest::Attestation {
+                user_data: None,
+                public_key: Some(tee_public_key.into()),
+                nonce: None,
+            },
+        ) {
+            NsmResponse::Attestation { document } => Ok(document),
+            _ => Err(VsockError::Protocol(String::from(
+                "NSM driver failed to compute attestation.",
+            ))),
+        }
+    }
+
+    #[cfg(not(feature = "without_attestation"))]
+    fn init_nsm_driver() -> Result<i32, VsockError> {
+        info!("Opening file descriptor to /dev/nsm driver.");
+        let nsm_fd = nsm_init();
+
+        if nsm_fd < 0 {
+            return Err(VsockError::Protocol(String::from(
+                "Failed to initialize NSM driver.",
+            )));
+        }
+
+        Ok(nsm_fd)
+    }
+}
+
+#[cfg(not(feature = "without_attestation"))]
+impl Drop for Server {
+    fn drop(&mut self) {
+        info!("Closing file descriptor to /dev/nsm driver.");
+        nsm_exit(self.nsm_fd);
+    }
+}

--- a/crates/shielder-setup/lib.rs
+++ b/crates/shielder-setup/lib.rs
@@ -1,8 +1,8 @@
 pub use shielder_circuits;
 
 pub mod consts {
-    pub const ARITY: usize = 7;
-    pub const TREE_HEIGHT: usize = 13;
+    pub const ARITY: usize = shielder_circuits::consts::merkle_constants::ARITY;
+    pub const TREE_HEIGHT: usize = shielder_circuits::consts::merkle_constants::NOTE_TREE_HEIGHT;
 }
 
 pub mod native_token {


### PR DESCRIPTION
This pull request introduces new `scheduler-common`, `scheduler-server` and  `scheduler-tee` crates, establishing a shared protocol and vsock communication layer for the scheduler system. It also updates and adds several dependencies in the workspace to support these new crates and features. The most important changes are summarized below.

It is an initial setup for the scheduler system. The key logic are still to be implemented (Note `todo!(...)` and `NOT_IMPLEMENTED`)

**New Crates and Shared Protocol**

* Added new `scheduler-common` crate, which provides shared types, protocol definitions, and vsock communication primitives for the scheduler system. This includes serialization utilities, request/response protocol enums, and vsock client/server abstractions. 
* Added new `scheduler-server` crate, which sets up the server application, command-line argument parsing, error handling, health check endpoint, and integrates with the new protocol and vsock communication layer.
* Added new `scheduler-tee` crate.

**Dependency and Workspace Updates**

* Updated and added several dependencies in `Cargo.toml` to support vsock communication, async processing, base64 serialization, and metrics. Notable additions include `aws-nitro-enclaves-nsm-api`, `base64`, `enum-map`, `futures`, `tokio-task-pool`, `tokio-util`, `tokio-vsock`, and `vsock`. Existing dependencies such as `metrics-exporter-prometheus`, `tokio`, `tower-http`, and `tracing-subscriber` were updated to newer versions.

**Build and Lint Tooling**

* Added `Makefile`s for `scheduler-common`, `scheduler-server` and `scheduler-tee` crates to provide formatting and linting commands.