### PR TITLE
Verify token kind uniqueness

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,16 @@ NETWORK=anvil make deploy-contracts
 Most of the Shielder is licensed under the Apache-2.0 License. See the LICENSE file for more details.
 
 Some of the crates are licensed with LICENSE-GPL-3.0-only-with-Classpath-exception:
-* `crates/shielder-circuits`
+
+- `crates/shielder-circuits`
 
 Some of the crates are licensed with MIT:
-* `crates/transcript`
+
+- `crates/transcript`
 
 ## Circuits
 
-Originally, `shielder-circuits` crate was placed in a different [repo](https://github.com/Cardinal-Cryptography/zkOS-circuits) and migrated without 
+Originally, `shielder-circuits` crate was placed in a different [repo](https://github.com/Cardinal-Cryptography/zkOS-circuits) and migrated without
 preserving git history to this repo, so in case one needs to check `git blame`, please visit original repo.
 
 [blanksquare-homepage]: https://blanksquare.io/

--- a/crates/shielder-relayer/src/config/tests.rs
+++ b/crates/shielder-relayer/src/config/tests.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::address;
+use anyhow::Result;
 use assert2::assert;
 use rust_decimal::Decimal;
 use shielder_relayer::{RELAYER_PORT_ENV, RELAYER_SIGNING_KEYS_ENV};
@@ -12,7 +13,7 @@ fn verify_cli() {
 }
 
 #[test]
-fn config_resolution() {
+fn config_resolution() -> Result<()> {
     // ---- Target configuration. --------------------------------------------------------------
     let logging_format = LoggingFormat::Json;
     let host = DEFAULT_HOST.to_string();
@@ -138,6 +139,8 @@ fn config_resolution() {
     }
 
     // ---- Test. ------------------------------------------------------------------------------
-    let resolved_config = resolve_config_from_cli_config(cli_config);
+    let resolved_config = resolve_config_from_cli_config(cli_config)?;
     assert!(resolved_config == expected_config);
+
+    Ok(())
 }

--- a/crates/shielder-relayer/src/main.rs
+++ b/crates/shielder-relayer/src/main.rs
@@ -74,7 +74,7 @@ struct ApiDoc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let server_config = resolve_config();
+    let server_config = resolve_config()?;
     init_logging(server_config.logging_format)?;
 
     info!("Starting Shielder relayer.");


### PR DESCRIPTION
We use token kind to identify tokens in the price feed. This makes sure there aren't any duplicates without going too deep into refactoring that.