### PR TITLE
Try smaller runner image

### DIFF
--- a/.github/workflows/_build-wasm-packages.yml
+++ b/.github/workflows/_build-wasm-packages.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   main:
     name: Build wasm packages
-    runs-on: github-large-runner-x64-16-cpu-64-gb-ram-600-gb-disk
+    runs-on: github-large-runner-x64-8-cpu-32-gb-ram-300-gb-disk
     timeout-minutes: 10
     steps:
       - name: Checkout source code

--- a/.github/workflows/_measure-gas-and-contract-size.yml
+++ b/.github/workflows/_measure-gas-and-contract-size.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Measure gas and verifier code size
-    runs-on: github-large-runner-x64-16-cpu-64-gb-ram-600-gb-disk
+    runs-on: github-large-runner-x64-8-cpu-32-gb-ram-300-gb-disk
     timeout-minutes: 10
     steps:
       - name: Checkout code (from the current branch)

--- a/.github/workflows/_rust-crates-checks.yml
+++ b/.github/workflows/_rust-crates-checks.yml
@@ -104,7 +104,7 @@ jobs:
 
   run-heavy-tests:
     name: Run heavy tests for ${{ matrix.crate }}
-    runs-on: github-large-runner-x64-16-cpu-64-gb-ram-600-gb-disk
+    runs-on: github-large-runner-x64-8-cpu-32-gb-ram-300-gb-disk
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-deploy-shielder-relayer.yml
+++ b/.github/workflows/build-and-deploy-shielder-relayer.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-and-push:
     name: Build and push shielder-relayer
-    runs-on: github-large-runner-x64-16-cpu-64-gb-ram-600-gb-disk
+    runs-on: github-large-runner-x64-8-cpu-32-gb-ram-300-gb-disk
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     if: github.event.inputs.environment != 'none'
     name: Deploy shielder-relayer
     needs: [build-and-push]
-    runs-on: github-large-runner-x64-16-cpu-64-gb-ram-600-gb-disk
+    runs-on: github-large-runner-x64-8-cpu-32-gb-ram-300-gb-disk
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/manual-publish-npm.yml
+++ b/.github/workflows/manual-publish-npm.yml
@@ -30,7 +30,7 @@ jobs:
       github.event.inputs.package == 'shielder-sdk-crypto' ||
       github.event.inputs.package == 'shielder-sdk-crypto-wasm' ||
       github.event.inputs.package == 'shielder-sdk-crypto-wasm-light'
-    runs-on: [self-hosted, Linux, X64, medium]
+    runs-on: github-large-runner-x64-8-cpu-32-gb-ram-300-gb-disk
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
As you can see https://github.com/Cardinal-Cryptography/blanksquare-monorepo/actions/runs/17584201856, as compared to an example run from `main` https://github.com/Cardinal-Cryptography/blanksquare-monorepo/actions/runs/17561316333, no time change on total workflow run time (22m30s). Smaller runner is 2x cheaper. 

Also, this PR fix last outstanding `self-hosted` runner reference, preventing atm for one job to start.