### PR TITLE
Fix awaiting receipt on Base doesn't guarantee transaction inclusion

### DIFF
--- a/ts/shielder-sdk/__tests/client/actions.test.ts
+++ b/ts/shielder-sdk/__tests/client/actions.test.ts
@@ -35,6 +35,7 @@ describe("ShielderActions", () => {
   let mockNewAccountAction: Mocked<NewAccountAction>;
   let mockDepositAction: Mocked<DepositAction>;
   let mockWithdrawAction: Mocked<WithdrawAction>;
+  let unsubscribeFromBlockNumber: () => void;
   let mockPublicClient: Mocked<PublicClient>;
   let mockCallbacks: ShielderCallbacks;
   let mockAccountState: AccountStateMerkleIndexed;
@@ -254,10 +255,21 @@ describe("ShielderActions", () => {
       sendCalldataWithRelayer: vitest.fn()
     } as unknown as Mocked<WithdrawAction>;
 
+    unsubscribeFromBlockNumber = vitest.fn();
+
     mockPublicClient = {
       waitForTransactionReceipt: vitest.fn().mockResolvedValue({
-        status: "success"
-      })
+        status: "success",
+        blockNumber: 2n
+      }),
+      watchBlockNumber: vitest.fn().mockImplementation(
+        (options: { onBlockNumber: (blockNumber: bigint) => void }) => {
+          setTimeout(options.onBlockNumber, 0, 1n);
+          setTimeout(options.onBlockNumber, 0, 2n);
+
+          return unsubscribeFromBlockNumber;
+        }
+      ),
     } as unknown as Mocked<PublicClient>;
 
     mockCallbacks = {
@@ -302,6 +314,7 @@ describe("ShielderActions", () => {
           gas_cost_native: 0n,
           gas_cost_fee_token: 0n,
           relayer_cost_native: 0n,
+          relayer_cost_fee_token: 0n,
           pocket_money_native: 0n,
           pocket_money_fee_token: 0n,
           commission_native: 0n,
@@ -313,7 +326,8 @@ describe("ShielderActions", () => {
           native_token_unit_price: "1",
           fee_token_price: "1",
           fee_token_unit_price: "1",
-          token_price_ratio: "1"
+          token_price_ratio: "1",
+          token_unit_price_ratio: "1"
         }
       };
 
@@ -380,6 +394,8 @@ describe("ShielderActions", () => {
             hash: mockTxHash
           }
         );
+        expect(mockPublicClient.watchBlockNumber).toHaveBeenCalledOnce();
+        expect(unsubscribeFromBlockNumber).toHaveBeenCalledOnce();
         expect(mockStateSynchronizer.syncSingleAccount).toHaveBeenCalledWith(
           mockToken
         );

--- a/ts/shielder-sdk/src/client/actions.ts
+++ b/ts/shielder-sdk/src/client/actions.ts
@@ -19,6 +19,7 @@ import { contractVersion } from "@/constants";
 import { Calldata } from "@/actions/types";
 import { AccountStateMerkleIndexed } from "@/state/types";
 import { handleShielderError } from "@/utils/errorHandler";
+import waitForTransactionInclusion from "@/utils/waitForTransactionInclusion";
 
 export class ShielderActions {
   constructor(
@@ -270,9 +271,11 @@ export class ShielderActions {
   }
 
   private async waitAndSync(token: Token, txHash: Hash) {
-    const txReceipt = await this.publicClient.waitForTransactionReceipt({
-      hash: txHash
+    const txReceipt = await waitForTransactionInclusion({
+      hash: txHash,
+      publicClient: this.publicClient
     });
+
     if (txReceipt.status !== "success") {
       throw new Error("Transaction failed");
     }

--- a/ts/shielder-sdk/src/utils/waitForTransactionInclusion.ts
+++ b/ts/shielder-sdk/src/utils/waitForTransactionInclusion.ts
@@ -1,0 +1,34 @@
+import type { Hash, PublicClient, TransactionReceipt } from "viem";
+
+const waitForTransactionInclusion = async ({
+  hash,
+  publicClient
+}: {
+  hash: Hash;
+  publicClient: PublicClient;
+}): Promise<TransactionReceipt> => {
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+
+  // Since the introduction of flashblocks on Base chain,
+  // awaiting the transaction receipt is not enough
+  // to see the transaction effects.
+  await new Promise<void>((resolve, reject) => {
+    const unwatch = publicClient.watchBlockNumber({
+      onBlockNumber: (blockNumber) => {
+        if (blockNumber >= receipt.blockNumber) {
+          unwatch();
+          resolve();
+        }
+      },
+      onError: (error) => {
+        unwatch();
+        reject(error);
+      },
+      emitOnBegin: true
+    });
+  });
+
+  return receipt;
+};
+
+export default waitForTransactionInclusion;


### PR DESCRIPTION
Add wait for transaction inclusion util; use it in shielder sync to avoid race condition on Base.

On Base (because of flashblocks?) awaiting transaction receipt doesn't guarantee that transaction has been included. This means that transaction state change e.i. balance update or nonce change might not be visible. To fix this apart from await the transaction receipt I await block number to be greater or equal to transaction block number. Empirically this seems to work. It also makes sense :sweat_smile: 

Alternatively we could add `confirmations = 2`. It would mean we're waiting for next block after transaction inclusion, but it could be a cleaner solution (haven't tested it, though). Default `confirmations = 1` doesn't check for block number. I've decided against it, because of e.g. Ethereum that's 12 more seconds, but perhaps we're willing to take it for a more battle tested viem's solution. LMK WYT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * More reliable transaction confirmation by waiting for on-chain inclusion before proceeding.
  * Automatic single-account state sync after successful transactions for up-to-date balances and activity.

* Bug Fixes
  * Reduces cases where transactions appeared confirmed too early, improving stability on chains prone to reorgs/flashblocks.
  * Improves overall consistency of post-transaction flows.

* Tests
  * Added block-number watching coverage and unsubscription verification.
  * Expanded relayer fee mock data for broader test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->