### PR TITLE
status endpoint in scheduler server + some fixes

### DIFF
--- a/crates/shielder-scheduler-server/README.md
+++ b/crates/shielder-scheduler-server/README.md
@@ -43,6 +43,7 @@ For local development and testing, you can use the `--disable-kms` command line 
 - **Validation Changes**: AWS configuration parameters become optional when `--disable-kms` is used
 
 When using `--disable-kms`:
+
 - The `shielder-scheduler-tee` must be run with cargo feature `local-run` and `PRIVATE_KEY_BASE64` environment variable
 - AWS parameters (AWS_REGION, KMS_KEY_ID, AWS_IAM_KMS_ROLE) become optional
 - The server uses dummy AWS credentials for TEE communication
@@ -146,12 +147,14 @@ CREATE TABLE scheduled_requests (
 The service can be configured using environment variables or command-line arguments:
 
 ### Server Configuration
+
 - `PUBLIC_PORT`: HTTP server port (default: 3000)
 - `METRICS_PORT`: Metrics endpoint port (default: 3001)
 - `BIND_ADDRESS`: Server bind address (default: 0.0.0.0)
 - `MAXIMUM_REQUEST_SIZE`: Maximum request size in bytes (default: 102400)
 
 ### Database Configuration
+
 - `DB_HOST`: Database host (default: localhost)
 - `DB_PORT`: Database port (default: 5432)
 - `DB_NAME`: Database name (default: scheduler-db)
@@ -160,6 +163,7 @@ The service can be configured using environment variables or command-line argume
 - `DB_USE_SSL`: Use SSL for database connection (default: false)
 
 ### TEE Configuration
+
 - `TEE_CID`: TEE context identifier for vsock communication (default: VMADDR_CID_HOST)
 - `TEE_PORT`: TEE port for vsock communication (default: 5000)
 - `TEE_TASK_POOL_CAPACITY`: Maximum concurrent TEE tasks (default: 100, max: 128)
@@ -167,22 +171,25 @@ The service can be configured using environment variables or command-line argume
 - `TEE_COMPUTE_TIMEOUT_SECS`: TEE response timeout in seconds (default: 60)
 
 ### Scheduler Processor Configuration
+
 - `SCHEDULER_INTERVAL_SECS`: How often to check for pending requests (default: 5)
 - `SCHEDULER_BATCH_SIZE`: Maximum requests to process per batch (default: 10)
 - `SCHEDULER_MAX_RETRY_COUNT`: Maximum retry attempts per request (default: 3)
 - `SCHEDULER_RETRY_DELAY_SECS`: Delay between retry attempts (default: 60)
 
 ### AWS & KMS Configuration
+
 - `--disable-kms`: Command line flag to disable KMS and use local private key for decryption (for development only)
 - `AWS_REGION`: AWS region for STS and KMS operations (required when KMS is enabled, optional with `--disable-kms`)
 - `AWS_IAM_KMS_ROLE`: IAM role name for KMS access (required when KMS is enabled, optional with `--disable-kms`)
-- `KMS_KEY_ID`: AWS KMS key identifier for encryption operations (required when KMS is enabled, optional with `--disable-kms`)  
+- `KMS_KEY_ID`: AWS KMS key identifier for encryption operations (required when KMS is enabled, optional with `--disable-kms`)
 - `KMS_PUBLIC_KEY`: Base64-encoded public key for KMS verification (required)
 - `AWS_STS_REFRESH_CREDENTIALS_PERIOD_SECONDS`: How often to refresh AWS STS credentials in seconds (default: 900, range: 900-1800)
 
 **Local Development**: When using the `--disable-kms` flag, AWS-related environment variables become optional. If not provided, dummy AWS credentials are used for local testing. The TEE must be run with cargo feature `local_run` and `PRIVATE_KEY_BASE64` environment variable.
 
 **Converting PEM to Base64**: If you have a PEM file, you can convert it to base64:
+
 ```bash
 # Remove PEM headers/footers and convert to single line base64
 cat your-public-key.pem | grep -v "BEGIN\|END" | tr -d '\n'
@@ -193,6 +200,7 @@ cat your-public-key.pem | grep -v "BEGIN\|END" | tr -d '\n'
 **Token Management**: The metadata token TTL is automatically set to twice the refresh period to ensure adequate overlap during credential rotation.
 
 **Validation**: The refresh period is constrained to 900-1800 seconds (15-30 minutes) to ensure:
+
 - Minimum security through frequent credential rotation (≤30 minutes)
 - Reasonable EC2 metadata service usage without excessive calls (≥15 minutes)
 - Optimal balance between security and operational efficiency
@@ -200,12 +208,13 @@ cat your-public-key.pem | grep -v "BEGIN\|END" | tr -d '\n'
 **STS Refresh Failure Behavior**: If AWS STS credential refresh fails during runtime, the server will shut down gracefully. This ensures that the service does not continue operating with expired credentials, maintaining security compliance. Operators should monitor for service restarts and address any underlying AWS IAM or network connectivity issues that may cause credential refresh failures.
 
 ### Blockchain Configuration
+
 - `NODE_RPC_URL`: RPC URL of the Ethereum node to connect to (required)
 - `SHIELDER_ADDRESS`: Address of the Shielder contract (required)
-- `RELAYER_RPC_URL`: URL of the relayer service (required)
-
+- `RELAYER_URL`: URL of the relayer service (required)
 
 ### Metrics Configuration
+
 - `METRICS_UPKEEP_TIMEOUT_SECS`: How often to perform metric upkeep (default: 60)
 - `METRICS_BUCKET_DURATION_SECS`: Duration of metric histogram buckets (default: 60)
 
@@ -216,16 +225,19 @@ The service is built with clear separation of concerns:
 ### Components
 
 1. **HTTP API Layer** (`handlers/`):
+
    - `health.rs`: Health check endpoint
    - `tee_public_key.rs`: TEE public key retrieval
    - `schedule_withdraw.rs`: Withdrawal request scheduling
 
 2. **Database Layer** (`db/`):
+
    - PostgreSQL connection management
    - Request storage and retrieval
    - Status tracking and updates
 
 3. **Scheduler Processor** (`scheduler_processor.rs`):
+
    - Background processing of scheduled requests
    - Batch processing with configurable limits
    - Retry logic with backoff
@@ -234,7 +246,8 @@ The service is built with clear separation of concerns:
    - TEE communication for calldata preparation
    - Response processing and relay submission
 
-4. **Relayer Communication** (`relayer_rpc_controller.rs`):
+4. **Relayer Communication** (`relayer_controller.rs`):
+
    - Communication with external relayer service
    - Fee quotation requests
    - Relay transaction submission
@@ -260,6 +273,7 @@ The service is built with clear separation of concerns:
 ## Example Usage
 
 **Prerequisites**:
+
 - EC2 instance with an IAM role that has KMS permissions
 - The EC2 instance must have access to EC2 instance metadata service (IMDSv2)
 - The IAM role name must match the configured `AWS_IAM_KMS_ROLE`
@@ -267,12 +281,13 @@ The service is built with clear separation of concerns:
 - AWS_STS_REFRESH_CREDENTIALS_PERIOD_SECONDS must be between 900 and 1800 seconds
 
 **Validation Examples**:
+
 ```bash
 # This will fail - refresh period too short
 export AWS_STS_REFRESH_CREDENTIALS_PERIOD_SECONDS=600
 cargo run  # Error: AWS_STS_REFRESH_CREDENTIALS_PERIOD_SECONDS must be at least 900 seconds
 
-# This will fail - refresh period too long  
+# This will fail - refresh period too long
 export AWS_STS_REFRESH_CREDENTIALS_PERIOD_SECONDS=2000
 cargo run  # Error: AWS_STS_REFRESH_CREDENTIALS_PERIOD_SECONDS must be at most 1800 seconds
 
@@ -284,11 +299,13 @@ cargo run  # Success
 **Command Line Usage Examples**:
 
 Production mode (with KMS):
+
 ```bash
 cargo run -- --kms-public-key <base64-key> --aws-region us-east-1 --kms-key-id <key-id> --aws-iam-kms-role <iam-role-name> --node-rpc-url <rpc-url> --shielder-address <contract-addr> --relayer-rpc-url <relayer-url>
 ```
 
 Local development mode (without KMS):
+
 ```bash
 cargo run -- --disable-kms --kms-public-key <base64-key> --node-rpc-url <rpc-url> --shielder-address <contract-addr> --relayer-rpc-url <relayer-url>
 ```

--- a/crates/shielder-scheduler-server/src/command_line_args.rs
+++ b/crates/shielder-scheduler-server/src/command_line_args.rs
@@ -128,9 +128,9 @@ pub struct CommandLineArgs {
     /// Address of the Shielder contract
     #[clap(long, env = "SHIELDER_ADDRESS")]
     pub shielder_address: String,
-    /// Relayer rpc URL
-    #[clap(long, env = "RELAYER_RPC_URL")]
-    pub relayer_rpc_url: String,
+    /// Relayer URL
+    #[clap(long, env = "RELAYER_URL")]
+    pub relayer_url: String,
 }
 
 impl CommandLineArgs {

--- a/crates/shielder-scheduler-server/src/db/schema.rs
+++ b/crates/shielder-scheduler-server/src/db/schema.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use shielder_scheduler_common::protocol::EncryptionEnvelope;
 use sqlx::{PgPool, Row};
 
-use crate::error::SchedulerServerError as Error;
+use crate::{error::SchedulerServerError as Error, handlers::get_status::GetStatusResponse};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheduledRequest {
@@ -84,14 +84,13 @@ pub async fn create_tables(pool: &PgPool) -> Result<(), Error> {
             token_address TEXT NOT NULL,
             relay_after TIMESTAMPTZ NOT NULL,
             status request_status NOT NULL DEFAULT 'pending',
-            created_at TIMESTAMPTZ NOT NULL DEFAULT &1,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             processed_at TIMESTAMPTZ,
             retry_count INTEGER NOT NULL DEFAULT 0,
             error_message TEXT
         )
         "#,
     )
-    .bind(Utc::now())
     .execute(pool)
     .await?;
 
@@ -227,4 +226,31 @@ pub async fn update_retry_attempt(
     .await?;
 
     Ok(())
+}
+
+pub async fn get_request_by_last_note_index(
+    pool: &PgPool,
+    last_note_index: &str,
+) -> Result<Option<GetStatusResponse>, Error> {
+    let row = sqlx::query(
+        r#"
+        SELECT last_note_index, status, created_at, processed_at
+        FROM scheduled_requests
+        WHERE last_note_index = $1
+        "#,
+    )
+    .bind(last_note_index)
+    .fetch_optional(pool)
+    .await?;
+
+    if let Some(row) = row {
+        Ok(Some(GetStatusResponse {
+            last_note_index: row.get("last_note_index"),
+            status: row.get("status"),
+            created_at: row.get("created_at"),
+            processed_at: row.get("processed_at"),
+        }))
+    } else {
+        Ok(None)
+    }
 }

--- a/crates/shielder-scheduler-server/src/handlers/get_status.rs
+++ b/crates/shielder-scheduler-server/src/handlers/get_status.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    response::IntoResponse,
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, instrument};
+
+use crate::{
+    db::{get_request_by_last_note_index, RequestStatus},
+    AppState,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetStatusResponse {
+    pub last_note_index: String,
+    pub status: RequestStatus,
+    pub created_at: DateTime<Utc>,
+    pub processed_at: Option<DateTime<Utc>>,
+}
+
+#[instrument(level = "info", skip_all)]
+pub async fn get_status(
+    State(state): State<Arc<AppState>>,
+    Path(last_note_index): Path<String>,
+) -> impl IntoResponse {
+    info!(
+        "Received get status request for last_note_index: {}",
+        last_note_index
+    );
+
+    match get_request_by_last_note_index(&state.db_pool, &last_note_index).await {
+        Ok(Some(res)) => {
+            info!(
+                "Found request with status: {:?} for last_note_index: {}",
+                res.status, last_note_index
+            );
+            (axum::http::StatusCode::OK, Json(res)).into_response()
+        }
+        Ok(None) => {
+            info!("No request found for last_note_index: {}", last_note_index);
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": "Request not found",
+                    "last_note_index": last_note_index
+                })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            error!(
+                "Failed to get request status for last_note_index {}: {:?}",
+                last_note_index, e
+            );
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "Failed to retrieve request status"
+                })),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/shielder-scheduler-server/src/handlers/health.rs
+++ b/crates/shielder-scheduler-server/src/handlers/health.rs
@@ -11,7 +11,7 @@ pub async fn health(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Response>, SchedulerServerError> {
     let tee_task_pool = state.tee_task_pool.clone();
-    let relayer_rpc_controller = state.relayer_rpc_controller.clone();
+    let relayer_controller = state.relayer_controller.clone();
 
     let tee_result = tee_task_pool
         .spawn(async move { tee_request(state, Request::Ping).await })
@@ -21,7 +21,7 @@ pub async fn health(
         .map_err(SchedulerServerError::JoinHandleError)??
         .map_err(SchedulerServerError::ProvingServerError);
 
-    relayer_rpc_controller.health_check().await?;
+    relayer_controller.health_check().await?;
 
     tee_result
 }

--- a/crates/shielder-scheduler-server/src/handlers/mod.rs
+++ b/crates/shielder-scheduler-server/src/handlers/mod.rs
@@ -9,6 +9,7 @@ use tracing::{info_span, Instrument as _};
 
 use crate::AppState;
 
+pub mod get_status;
 pub mod health;
 pub mod schedule_withdraw;
 pub mod tee_public_key;

--- a/crates/shielder-scheduler-server/src/main.rs
+++ b/crates/shielder-scheduler-server/src/main.rs
@@ -3,7 +3,7 @@ mod command_line_args;
 mod db;
 mod error;
 mod handlers;
-mod relayer_rpc_controller;
+mod relayer_controller;
 mod scheduler_processor;
 
 use std::{net::SocketAddrV4, sync::Arc, time::Duration};
@@ -29,7 +29,7 @@ use crate::{
     aws_session_tokens::AwsCredentials,
     command_line_args::CommandLineArgs,
     handlers::{self as server_handlers},
-    relayer_rpc_controller::RelayerRpcController,
+    relayer_controller::RelayerController,
     scheduler_processor::SchedulerProcessor,
 };
 
@@ -39,7 +39,7 @@ struct AppState {
     db_pool: db::PgPool,
     tee_task_pool: Arc<tokio_task_pool::Pool>,
     aws_credentials: Arc<Mutex<AwsCredentials>>,
-    relayer_rpc_controller: RelayerRpcController,
+    relayer_controller: RelayerController,
     shutdown_tx: watch::Sender<bool>,
 }
 
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Error> {
         }
     };
 
-    let relayer_rpc_controller = RelayerRpcController::new(options.relayer_rpc_url.clone());
+    let relayer_controller = RelayerController::new(options.relayer_url.clone());
 
     // Create shutdown signal channel
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -109,16 +109,16 @@ async fn main() -> Result<(), Error> {
         tee_task_pool,
         db_pool,
         aws_credentials: Arc::new(Mutex::new(aws_credentials)),
-        relayer_rpc_controller,
+        relayer_controller,
         shutdown_tx,
     });
 
     // Perform initial TEE public key verification to ensure the server is correctly configured
     info!("Performing initial TEE public key verification...");
-    let _verification_result =
-        server_handlers::tee_public_key::tee_public_key(axum::extract::State(app_state.clone()))
-            .await
-            .map_err(|e| Error::ParseError(format!("TEE public key verification failed: {}", e)))?;
+    // let _verification_result =
+    //     server_handlers::tee_public_key::tee_public_key(axum::extract::State(app_state.clone()))
+    //         .await
+    //         .map_err(|e| Error::ParseError(format!("TEE public key verification failed: {}", e)))?;
 
     info!("TEE public key verification successful");
 
@@ -150,6 +150,10 @@ async fn main() -> Result<(), Error> {
         .route(
             "/schedule_withdraw",
             post(server_handlers::schedule_withdraw::schedule_withdraw),
+        )
+        .route(
+            "/status/{last_note_index}",
+            get(server_handlers::get_status::get_status),
         )
         .layer(DefaultBodyLimit::max(
             app_state.options.maximum_request_size,

--- a/crates/shielder-scheduler-server/src/main.rs
+++ b/crates/shielder-scheduler-server/src/main.rs
@@ -115,10 +115,10 @@ async fn main() -> Result<(), Error> {
 
     // Perform initial TEE public key verification to ensure the server is correctly configured
     info!("Performing initial TEE public key verification...");
-    // let _verification_result =
-    //     server_handlers::tee_public_key::tee_public_key(axum::extract::State(app_state.clone()))
-    //         .await
-    //         .map_err(|e| Error::ParseError(format!("TEE public key verification failed: {}", e)))?;
+    let _verification_result =
+        server_handlers::tee_public_key::tee_public_key(axum::extract::State(app_state.clone()))
+            .await
+            .map_err(|e| Error::ParseError(format!("TEE public key verification failed: {}", e)))?;
 
     info!("TEE public key verification successful");
 

--- a/crates/shielder-scheduler-server/src/relayer_controller.rs
+++ b/crates/shielder-scheduler-server/src/relayer_controller.rs
@@ -9,15 +9,15 @@ use tracing::debug;
 
 use crate::error::SchedulerServerError;
 
-/// Controller for interacting with the relayer service via its RPC API.
+/// Controller for interacting with the relayer service via its API.
 #[derive(Clone, Eq, PartialEq, Debug, Default, Deserialize, Serialize)]
 
-pub struct RelayerRpcController {
+pub struct RelayerController {
     base_url: String,
 }
 
-impl RelayerRpcController {
-    /// Create a new RelayerRpcController with the given base URL.
+impl RelayerController {
+    /// Create a new RelayerController with the given base URL.
     /// Example: "https://base-testnet-shielder-relayer-v3.test.blanksquare.dev"
     pub fn new(base_url: String) -> Self {
         Self { base_url }

--- a/crates/shielder-scheduler-server/src/scheduler_processor.rs
+++ b/crates/shielder-scheduler-server/src/scheduler_processor.rs
@@ -222,7 +222,7 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
         };
 
         self.app_state
-            .relayer_rpc_controller
+            .relayer_controller
             .get_relayer_total_fee(token, pocket_money)
             .await
     }
@@ -256,7 +256,7 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
         let encryption_envelope = request.encryption_envelope.clone();
         let relayer_address = self
             .app_state
-            .relayer_rpc_controller
+            .relayer_controller
             .get_relayer_fee_address()
             .await?;
 
@@ -320,7 +320,7 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
                     quote: quoted_fee.into(),
                 };
                 self.app_state
-                    .relayer_rpc_controller
+                    .relayer_controller
                     .send_relay_query(relay_query)
                     .await?;
                 Ok(ProcessingResult { request_id })


### PR DESCRIPTION
- status endpoint for schedules
- fix db creation
- rename `relayer_rpc_*` to `relayer_*`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a status API (GET /status/{last_note_index}) to fetch request status and timestamps by last_note_index.

- Refactor
  - Renamed CLI/env/config from RELAYER_RPC_URL → RELAYER_URL and updated related runtime references.

- Documentation
  - Clarified local development with --disable-kms, optional AWS/KMS settings, KMS_KEY_ID behavior, dummy AWS credentials and disabled background refresh in that mode; updated usage/examples, validations, and PEM→base64 snippet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->