### PR TITLE
Add relay time to status response

### DIFF
--- a/crates/shielder-scheduler-server/src/db/schema.rs
+++ b/crates/shielder-scheduler-server/src/db/schema.rs
@@ -225,7 +225,7 @@ pub async fn get_request_by_last_note_index(
 ) -> Result<Option<GetStatusResponse>, Error> {
     let row = sqlx::query(
         r#"
-        SELECT last_note_index, status, created_at, processed_at
+        SELECT last_note_index, status, created_at, processed_at, relay_after
         FROM scheduled_requests
         WHERE last_note_index = $1
         "#,
@@ -240,6 +240,7 @@ pub async fn get_request_by_last_note_index(
             status: row.get("status"),
             created_at: row.get("created_at"),
             processed_at: row.get("processed_at"),
+            relay_after: row.get("relay_after"),
         }))
     } else {
         Ok(None)

--- a/crates/shielder-scheduler-server/src/handlers/get_status.rs
+++ b/crates/shielder-scheduler-server/src/handlers/get_status.rs
@@ -20,6 +20,7 @@ pub struct GetStatusResponse {
     pub status: RequestStatus,
     pub created_at: DateTime<Utc>,
     pub processed_at: Option<DateTime<Utc>>,
+    pub relay_after: DateTime<Utc>,
 }
 
 #[instrument(level = "info", skip_all)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status responses now include a new relay_after timestamp indicating the earliest time a request will be relayed. This helps clients plan retries and backoff more effectively.
  * The addition is backward-compatible and does not alter existing fields or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->