### PR TITLE
DynamoDB improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6377,7 +6377,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "uuid",
  "vsock",
 ]
 
@@ -7612,9 +7611,6 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
-dependencies = [
- "getrandom 0.3.3",
-]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ uniffi = { version = "0.29.4" }
 utoipa = { version = "5.3.1" }
 utoipa-axum = { version = "0.2.0" }
 utoipa-swagger-ui = { version = "9.0.0" }
-uuid = { version = "1.10.0", features = ["v4"] }
 vsock = "0.5.1"
 wasm-bindgen = { version = "=0.2.93" }
 wasm-bindgen-rayon = { version = "=1.2.1" }

--- a/crates/shielder-scheduler-server/Cargo.toml
+++ b/crates/shielder-scheduler-server/Cargo.toml
@@ -33,7 +33,6 @@ tokio-task-pool = { workspace = true, features = ["log"] }
 tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
 vsock = { workspace = true }
 
 [features]

--- a/crates/shielder-scheduler-server/README.md
+++ b/crates/shielder-scheduler-server/README.md
@@ -122,26 +122,6 @@ The service runs a background scheduler processor that:
 
 The scheduler processor can handle multiple requests in batches (configurable via `SCHEDULER_BATCH_SIZE`) and provides error handling with automatic retries.
 
-## Database Schema
-
-The service uses PostgreSQL with the following main table:
-
-```sql
-CREATE TABLE scheduled_requests (
-    id BIGSERIAL PRIMARY KEY,
-    payload BYTEA NOT NULL,
-    last_note_index TEXT NOT NULL,
-    pocket_money TEXT NOT NULL,
-    token_address TEXT NOT NULL,
-    relay_after TIMESTAMPTZ NOT NULL,
-    status request_status NOT NULL DEFAULT 'pending',
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    processed_at TIMESTAMPTZ,
-    retry_count INTEGER NOT NULL DEFAULT 0,
-    error_message TEXT
-);
-```
-
 ## Configuration
 
 The service can be configured using environment variables or command-line arguments:
@@ -298,34 +278,6 @@ Local development mode (in-memory storage, no AWS integration):
 
 ```bash
 cargo run --features local-run -- --kms-public-key <base64-key> --node-rpc-url <rpc-url> --shielder-address <contract-addr> --relayer-url <relayer-url>
-```
-
-### API Testing
-
-Schedule a withdrawal request:
-
-```bash
-curl -X POST http://localhost:3000/schedule_withdraw \
-  -H "Content-Type: application/json" \
-  -d '{
-    "payload": "SGVsbG8gV29ybGQ=",
-    "last_note_index": "12345",
-    "pocket_money": "500000000000000000",
-    "token_address": "0x1234567890123456789012345678901234567890",
-    "relay_after": 1693564800
-  }'
-```
-
-Check service health:
-
-```bash
-curl http://localhost:3000/health
-```
-
-Get TEE public key:
-
-```bash
-curl http://localhost:3000/public_key
 ```
 
 ### Generating Test RSA Keys

--- a/crates/shielder-scheduler-server/src/handlers/schedule_withdraw.rs
+++ b/crates/shielder-scheduler-server/src/handlers/schedule_withdraw.rs
@@ -81,21 +81,21 @@ pub async fn schedule_withdraw<Storage: StorageInterface>(
         relay_after,
     );
 
-    let request_id = request.id;
+    let request_last_note_index = request.last_note_index;
 
     match state.storage.insert_scheduled_request(request).await {
         Ok(_) => {
             info!(
-                "Successfully scheduled withdraw request with ID: {}",
-                request_id
+                "Successfully scheduled withdraw request with last_note_index: {}",
+                request_last_note_index
             );
             (
                 axum::http::StatusCode::CREATED,
                 Json(ScheduleWithdrawResponse {
-                    request_id: request_id.to_string(),
+                    request_id: request_last_note_index.to_string(),
                     message: format!(
-                        "Withdraw request scheduled successfully. Request ID: {}",
-                        request_id
+                        "Withdraw request scheduled successfully. Last note index: {}",
+                        request_last_note_index
                     ),
                 }),
             )

--- a/crates/shielder-scheduler-server/src/main.rs
+++ b/crates/shielder-scheduler-server/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Error> {
         .install()?;
 
     #[cfg(not(feature = "local-run"))]
-    let storage = storage::dynamo_db::DynamoDb::new().await?;
+    let storage = storage::dynamo_db::DynamoDb::new(&options.node_rpc_url).await?;
     #[cfg(feature = "local-run")]
     let storage = storage::in_memory::InMemoryStorage::new();
 

--- a/crates/shielder-scheduler-server/src/scheduler_processor.rs
+++ b/crates/shielder-scheduler-server/src/scheduler_processor.rs
@@ -113,6 +113,7 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
                     .update_request_status(
                         &request.last_note_index.to_string(),
                         RequestStatus::Completed,
+                        Some(Utc::now()),
                         None,
                     )
                     .await?;
@@ -135,6 +136,7 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
                             &request.last_note_index.to_string(),
                             new_relay_after,
                             new_retry_count,
+                            Some(Utc::now()),
                             Some(&e.to_string()),
                         )
                         .await?;
@@ -148,6 +150,7 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
                         .update_request_status(
                             &request.last_note_index.to_string(),
                             RequestStatus::Failed,
+                            Some(Utc::now()),
                             Some(&e.to_string()),
                         )
                         .await?;

--- a/crates/shielder-scheduler-server/src/scheduler_processor.rs
+++ b/crates/shielder-scheduler-server/src/scheduler_processor.rs
@@ -96,21 +96,31 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
 
     #[instrument(level = "info", skip_all)]
     async fn process_single_request(&self, request: ScheduledRequest) -> Result<()> {
-        info!("Processing request ID: {}", request.id);
+        info!(
+            "Processing request last_note_index: {}",
+            request.last_note_index
+        );
         let request_retry_count = request.retry_count;
 
         match self.process_request_logic(&request).await {
             Ok(_) => {
-                info!("Successfully processed request ID: {}", request.id);
+                info!(
+                    "Successfully processed request last_note_index: {}",
+                    request.last_note_index
+                );
                 self.app_state
                     .storage
-                    .update_request_status(request.id, RequestStatus::Completed, None)
+                    .update_request_status(
+                        &request.last_note_index.to_string(),
+                        RequestStatus::Completed,
+                        None,
+                    )
                     .await?;
             }
             Err(e) => {
                 warn!(
-                    "Request processing failed for ID: {}, error: {:?}",
-                    request.id, e
+                    "Request processing failed for last_note_index: {}, error: {:?}",
+                    request.last_note_index, e
                 );
 
                 if request_retry_count < self.app_state.options.scheduler_max_retry_count as i32 {
@@ -122,7 +132,7 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
                     self.app_state
                         .storage
                         .update_retry_attempt(
-                            request.id,
+                            &request.last_note_index.to_string(),
                             new_relay_after,
                             new_retry_count,
                             Some(&e.to_string()),
@@ -130,13 +140,13 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
                         .await?;
                 } else {
                     warn!(
-                        "Request ID {} has reached maximum retry count, marking as Failed",
-                        request.id
+                        "Request last_note_index {} has reached maximum retry count, marking as Failed",
+                        request.last_note_index
                     );
                     self.app_state
                         .storage
                         .update_request_status(
-                            request.id,
+                            &request.last_note_index.to_string(),
                             RequestStatus::Failed,
                             Some(&e.to_string()),
                         )
@@ -161,8 +171,8 @@ Please check the SHIELDER_ADDRESS environment variable or --shielder-address arg
         match tee_response {
             Response::PrepareRelayCalldata { calldata } => {
                 info!(
-                    "Successfully prepared relay calldata for request ID: {}",
-                    request.id,
+                    "Successfully prepared relay calldata for request last_note_index: {}",
+                    request.last_note_index,
                 );
                 let relay_query = RelayQuery {
                     calldata,

--- a/crates/shielder-scheduler-server/src/storage/dynamo_db.rs
+++ b/crates/shielder-scheduler-server/src/storage/dynamo_db.rs
@@ -1,27 +1,29 @@
 use aws_sdk_dynamodb::{
     error::SdkError,
-    operation::{describe_table::DescribeTableError, put_item::PutItemError},
+    operation::describe_table::DescribeTableError,
     types::{
-        AttributeDefinition, AttributeValue, KeySchemaElement, KeyType, ProvisionedThroughput,
-        ScalarAttributeType,
+        AttributeDefinition, AttributeValue, BillingMode, GlobalSecondaryIndex, KeySchemaElement,
+        KeyType, Projection, ProjectionType, ScalarAttributeType,
     },
     Client,
 };
 use chrono::{DateTime, Utc};
+use serde::Deserialize;
 
 use crate::storage::{RequestStatus, ScheduledRequest, StorageError, StorageInterface};
 
-const TABLE_NAME: &str = "ScheduledRequests";
-
 pub struct DynamoDb {
     client: Client,
+    table_name: String,
 }
 
 impl DynamoDb {
-    pub async fn new() -> Result<Self, StorageError> {
+    pub async fn new(rpc_url: &str) -> Result<Self, StorageError> {
         let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
         let client = Client::new(&config);
-        let db = Self { client };
+        let chain_id = get_chain_id(rpc_url).await?;
+        let table_name = format!("scheduled-requests-{}", chain_id);
+        let db = Self { client, table_name };
         db.create_table_if_not_exists().await?;
         Ok(db)
     }
@@ -31,7 +33,7 @@ impl DynamoDb {
         match self
             .client
             .describe_table()
-            .table_name(TABLE_NAME)
+            .table_name(&self.table_name)
             .send()
             .await
         {
@@ -43,29 +45,75 @@ impl DynamoDb {
             }
         }
 
-        let attr_def = AttributeDefinition::builder()
-            .attribute_name("id")
+        // Primary key: last_note_index
+        let last_note_index_attr = AttributeDefinition::builder()
+            .attribute_name("last_note_index")
             .attribute_type(ScalarAttributeType::S)
             .build()
-            .map_err(|e| StorageError::Internal(format!("AttrDef build error: {e}")))?;
-        let key_schema = KeySchemaElement::builder()
-            .attribute_name("id")
+            .map_err(|e| {
+                StorageError::Internal(format!("LastNoteIndex AttrDef build error: {e}"))
+            })?;
+
+        let primary_key_schema = KeySchemaElement::builder()
+            .attribute_name("last_note_index")
             .key_type(KeyType::Hash)
             .build()
-            .map_err(|e| StorageError::Internal(format!("KeySchema build error: {e}")))?;
-        let throughput = ProvisionedThroughput::builder()
-            .read_capacity_units(5)
-            .write_capacity_units(5)
+            .map_err(|e| {
+                StorageError::Internal(format!("PrimaryKey KeySchema build error: {e}"))
+            })?;
+
+        // GSI attributes
+        let status_attr = AttributeDefinition::builder()
+            .attribute_name("status")
+            .attribute_type(ScalarAttributeType::S)
             .build()
-            .map_err(|e| StorageError::Internal(format!("Throughput build error: {e}")))?;
+            .map_err(|e| StorageError::Internal(format!("Status AttrDef build error: {e}")))?;
+
+        let relay_after_attr = AttributeDefinition::builder()
+            .attribute_name("relay_after")
+            .attribute_type(ScalarAttributeType::N)
+            .build()
+            .map_err(|e| StorageError::Internal(format!("RelayAfter AttrDef build error: {e}")))?;
+
+        // GSI definition
+        let gsi = GlobalSecondaryIndex::builder()
+            .index_name("StatusRelayAfterIndex")
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name("status")
+                    .key_type(KeyType::Hash)
+                    .build()
+                    .map_err(|e| {
+                        StorageError::Internal(format!("GSI Hash KeySchema build error: {e}"))
+                    })?,
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name("relay_after")
+                    .key_type(KeyType::Range)
+                    .build()
+                    .map_err(|e| {
+                        StorageError::Internal(format!("GSI Range KeySchema build error: {e}"))
+                    })?,
+            )
+            .projection(
+                Projection::builder()
+                    .projection_type(ProjectionType::All)
+                    .build(),
+            )
+            .build()
+            .map_err(|e| StorageError::Internal(format!("GSI build error: {e}")))?;
 
         if let Err(e) = self
             .client
             .create_table()
-            .table_name(TABLE_NAME)
-            .attribute_definitions(attr_def)
-            .key_schema(key_schema)
-            .provisioned_throughput(throughput)
+            .table_name(&self.table_name)
+            .attribute_definitions(last_note_index_attr)
+            .attribute_definitions(status_attr)
+            .attribute_definitions(relay_after_attr)
+            .key_schema(primary_key_schema)
+            .global_secondary_indexes(gsi)
+            .billing_mode(BillingMode::PayPerRequest)
             .send()
             .await
         {
@@ -77,23 +125,26 @@ impl DynamoDb {
         Ok(())
     }
 
-    async fn get_item_by_id(&self, id: u128) -> Result<Option<ScheduledRequest>, StorageError> {
-        let id_str = id.to_string();
+    async fn get_item_by_last_note_index(
+        &self,
+        last_note_index: &str,
+    ) -> Result<Option<ScheduledRequest>, StorageError> {
         let out = self
             .client
             .get_item()
-            .table_name(TABLE_NAME)
-            .key("id", AttributeValue::S(id_str))
+            .table_name(&self.table_name)
+            .key(
+                "last_note_index",
+                AttributeValue::S(last_note_index.to_string()),
+            )
             .send()
             .await
             .map_err(|e| map_internal("get_item", e))?;
 
         if let Some(item) = out.item() {
-            if let Some(AttributeValue::S(payload_attr)) = item.get("payload") {
-                let req: ScheduledRequest = serde_json::from_str(payload_attr).map_err(|e| {
-                    StorageError::Internal(format!(
-                        "Failed to deserialize scheduled request payload: {e}"
-                    ))
+            if let Some(AttributeValue::S(request_attr)) = item.get("request") {
+                let req: ScheduledRequest = serde_json::from_str(request_attr).map_err(|e| {
+                    StorageError::Internal(format!("Failed to deserialize scheduled request: {e}"))
                 })?;
                 return Ok(Some(req));
             }
@@ -101,38 +152,41 @@ impl DynamoDb {
         Ok(None)
     }
 
-    async fn put_full_request(&self, request: &ScheduledRequest) -> Result<(), StorageError> {
-        let payload = serde_json::to_string(request).map_err(|e| {
-            StorageError::Internal(format!("Failed to serialize request payload: {e}"))
-        })?;
+    async fn put_request(
+        &self,
+        request: &ScheduledRequest,
+        condition_expression: Option<&str>,
+    ) -> Result<(), StorageError> {
+        let request_serialized = serde_json::to_string(&request)
+            .map_err(|e| StorageError::Internal(format!("Failed to serialize request: {e}")))?;
 
         let mut builder = self.client.put_item();
         builder = builder
-            .table_name(TABLE_NAME)
-            .item("id", AttributeValue::S(request.id.to_string()))
+            .table_name(&self.table_name)
+            .item(
+                "last_note_index",
+                AttributeValue::S(request.last_note_index.to_string()),
+            )
             .item(
                 "status",
                 AttributeValue::S(status_to_str(&request.status).to_string()),
             )
             .item(
                 "relay_after",
-                AttributeValue::N(request.relay_after.timestamp().to_string()),
+                AttributeValue::N(request.relay_after.timestamp_millis().to_string()),
             )
             .item(
                 "created_at",
                 AttributeValue::N(request.created_at.timestamp().to_string()),
             )
-            .item(
-                "last_note_index",
-                AttributeValue::S(request.last_note_index.to_string()),
-            )
-            .item("payload", AttributeValue::S(payload));
+            .item("request", AttributeValue::S(request_serialized));
 
-        if request.error_message.is_some() {
-            builder = builder.item(
-                "error_message",
-                AttributeValue::S(request.error_message.clone().unwrap()),
-            );
+        if let Some(condition) = condition_expression {
+            builder = builder.condition_expression(condition);
+        }
+
+        if let Some(error_msg) = &request.error_message {
+            builder = builder.item("error_message", AttributeValue::S(error_msg.clone()));
         }
         if let Some(processed_at) = request.processed_at {
             builder = builder.item(
@@ -154,52 +208,17 @@ impl StorageInterface for DynamoDb {
         &self,
         request: ScheduledRequest,
     ) -> Result<(), StorageError> {
-        let payload = serde_json::to_string(&request)
-            .map_err(|e| StorageError::Internal(format!("Failed to serialize request: {e}")))?;
-
-        let mut builder = self
-            .client
-            .put_item()
-            .table_name(TABLE_NAME)
-            .condition_expression("attribute_not_exists(id)")
-            .item("id", AttributeValue::S(request.id.to_string()))
-            .item(
-                "status",
-                AttributeValue::S(status_to_str(&request.status).to_string()),
-            )
-            .item(
-                "relay_after",
-                AttributeValue::N(request.relay_after.timestamp().to_string()),
-            )
-            .item(
-                "created_at",
-                AttributeValue::N(request.created_at.timestamp().to_string()),
-            )
-            .item(
-                "last_note_index",
-                AttributeValue::S(request.last_note_index.to_string()),
-            )
-            .item("payload", AttributeValue::S(payload));
-
-        if let Some(err) = &request.error_message {
-            builder = builder.item("error_message", AttributeValue::S(err.clone()));
-        }
-        if let Some(processed_at) = request.processed_at {
-            builder = builder.item(
-                "processed_at",
-                AttributeValue::N(processed_at.timestamp().to_string()),
-            );
-        }
-
-        match builder.send().await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                if is_conditional_check_failed(&e) {
-                    Err(StorageError::DuplicateEntry(request.id))
-                } else {
-                    Err(map_internal("put_item", e))
-                }
+        match self
+            .put_request(&request, Some("attribute_not_exists(last_note_index)"))
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(StorageError::Internal(msg)) if msg.contains("ConditionalCheckFailedException") => {
+                Err(StorageError::DuplicateEntry(
+                    request.last_note_index.to_string(),
+                ))
             }
+            Err(e) => Err(e),
         }
     }
 
@@ -207,156 +226,88 @@ impl StorageInterface for DynamoDb {
         &self,
         limit: usize,
     ) -> Result<Vec<ScheduledRequest>, StorageError> {
-        // Scan for pending or processing requests whose relay_after is <= now
-        let now = Utc::now().timestamp().to_string();
-        let out_res = self
+        let now = Utc::now().timestamp_millis().to_string();
+
+        let result = self
             .client
-            .scan()
-            .table_name(TABLE_NAME)
-            .filter_expression("#status IN (:pending, :processing) AND relay_after <= :now")
+            .query()
+            .table_name(&self.table_name)
+            .index_name("StatusRelayAfterIndex")
+            .key_condition_expression("#status = :status AND relay_after <= :max_time")
             .expression_attribute_names("#status", "status")
             .expression_attribute_values(
-                ":pending",
+                ":status",
                 AttributeValue::S(status_to_str(&RequestStatus::Pending).to_string()),
             )
-            .expression_attribute_values(
-                ":processing",
-                AttributeValue::S(status_to_str(&RequestStatus::Processing).to_string()),
-            )
-            .expression_attribute_values(":now", AttributeValue::N(now))
+            .expression_attribute_values(":max_time", AttributeValue::N(now))
+            .limit(limit as i32)
             .send()
-            .await;
-        let out = match out_res {
-            Ok(o) => o,
-            Err(e) => return Err(map_internal("scan", e)),
-        };
+            .await
+            .map_err(|e| map_internal("query", e))?;
 
-        let mut requests: Vec<ScheduledRequest> = Vec::new();
-        for item in out.items() {
-            if let Some(AttributeValue::S(payload_str)) = item.get("payload") {
-                match serde_json::from_str::<ScheduledRequest>(payload_str.as_str()) {
-                    Ok(req) => requests.push(req),
-                    Err(_e) => { /* skip malformed */ }
-                }
+        let mut requests = Vec::new();
+        for item in result.items() {
+            if let Some(AttributeValue::S(request_attr)) = item.get("request") {
+                let req: ScheduledRequest =
+                    serde_json::from_str(request_attr.as_str()).map_err(|e| {
+                        StorageError::Internal(format!(
+                            "Failed to deserialize scheduled request: {e}"
+                        ))
+                    })?;
+                requests.push(req);
             }
         }
-        // Sort by relay_after then take limit
-        requests.sort_by(|a, b| a.relay_after.cmp(&b.relay_after));
-        Ok(requests.into_iter().take(limit).collect())
+
+        Ok(requests)
     }
 
     async fn update_request_status(
         &self,
-        id: u128,
+        last_note_index: &str,
         status: RequestStatus,
         error_message: Option<&str>,
     ) -> Result<(), StorageError> {
-        let Some(mut existing) = self.get_item_by_id(id).await? else {
-            return Err(StorageError::NotFound(id.to_string()));
+        let Some(mut existing) = self.get_item_by_last_note_index(last_note_index).await? else {
+            return Err(StorageError::NotFound(last_note_index.to_string()));
         };
         existing.status = status;
         existing.error_message = error_message.map(|s| s.to_string());
-        let payload = serde_json::to_string(&existing).map_err(|e| {
-            StorageError::Internal(format!("Failed to serialize updated request: {e}"))
-        })?;
+        existing.processed_at = Some(Utc::now());
 
-        let mut builder = self
-            .client
-            .put_item()
-            .table_name(TABLE_NAME)
-            .condition_expression("attribute_exists(id)")
-            .item("id", AttributeValue::S(existing.id.to_string()))
-            .item(
-                "status",
-                AttributeValue::S(status_to_str(&existing.status).to_string()),
-            )
-            .item(
-                "relay_after",
-                AttributeValue::N(existing.relay_after.timestamp().to_string()),
-            )
-            .item(
-                "created_at",
-                AttributeValue::N(existing.created_at.timestamp().to_string()),
-            )
-            .item(
-                "last_note_index",
-                AttributeValue::S(existing.last_note_index.to_string()),
-            )
-            .item("payload", AttributeValue::S(payload));
-
-        if let Some(err) = &existing.error_message {
-            builder = builder.item("error_message", AttributeValue::S(err.clone()));
-        }
-        if let Some(processed_at) = existing.processed_at {
-            builder = builder.item(
-                "processed_at",
-                AttributeValue::N(processed_at.timestamp().to_string()),
-            );
-        }
-
-        match builder.send().await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                if is_conditional_check_failed(&e) {
-                    Err(StorageError::NotFound(id.to_string()))
-                } else {
-                    Err(map_internal("put_item", e))
-                }
-            }
-        }
+        // Simple put since last_note_index (primary key) doesn't change
+        self.put_request(&existing, None).await
     }
 
     async fn update_retry_attempt(
         &self,
-        id: u128,
+        last_note_index: &str,
         new_relay_after: DateTime<Utc>,
         new_retry_count: i32,
         new_error_message: Option<&str>,
     ) -> Result<(), StorageError> {
-        let Some(mut existing) = self.get_item_by_id(id).await? else {
-            return Err(StorageError::NotFound(id.to_string()));
+        let Some(mut existing) = self.get_item_by_last_note_index(last_note_index).await? else {
+            return Err(StorageError::NotFound(last_note_index.to_string()));
         };
         existing.relay_after = new_relay_after;
         existing.retry_count = new_retry_count;
         existing.error_message = new_error_message.map(|s| s.to_string());
-        self.put_full_request(&existing).await
+
+        // Simple put since last_note_index (primary key) doesn't change
+        self.put_request(&existing, None).await
     }
 
     async fn get_request_by_last_note_index(
         &self,
         last_note_index: &str,
     ) -> Result<Option<ScheduledRequest>, StorageError> {
-        let out = self
-            .client
-            .scan()
-            .table_name(TABLE_NAME)
-            .filter_expression("#lni = :lni")
-            .expression_attribute_names("#lni", "last_note_index")
-            .expression_attribute_values(":lni", AttributeValue::S(last_note_index.to_string()))
-            .send()
-            .await
-            .map_err(|e| map_internal("scan", e))?;
-
-        let mut matches: Vec<ScheduledRequest> = Vec::new();
-        for item in out.items() {
-            if let Some(AttributeValue::S(payload_str)) = item.get("payload") {
-                if let Ok(req) = serde_json::from_str::<ScheduledRequest>(payload_str.as_str()) {
-                    matches.push(req);
-                }
-            }
-        }
-        if matches.is_empty() {
-            return Ok(None);
-        }
-        matches.sort_by(|a, b| a.created_at.cmp(&b.created_at));
-        Ok(matches.into_iter().next())
+        // Direct lookup by primary key
+        self.get_item_by_last_note_index(last_note_index).await
     }
 }
 
 fn status_to_str(status: &RequestStatus) -> &'static str {
     match status {
         RequestStatus::Pending => "pending",
-        RequestStatus::Processing => "processing",
         RequestStatus::Completed => "completed",
         RequestStatus::Failed => "failed",
     }
@@ -364,10 +315,6 @@ fn status_to_str(status: &RequestStatus) -> &'static str {
 
 fn is_resource_not_found(e: &SdkError<DescribeTableError>) -> bool {
     matches!(e, SdkError::ServiceError(inner) if inner.err().is_resource_not_found_exception())
-}
-
-fn is_conditional_check_failed(e: &SdkError<PutItemError>) -> bool {
-    matches!(e, SdkError::ServiceError(inner) if inner.err().is_conditional_check_failed_exception())
 }
 
 fn map_internal<E: std::fmt::Display>(op: &str, e: SdkError<E>) -> StorageError {
@@ -378,4 +325,38 @@ fn map_internal<E: std::fmt::Display>(op: &str, e: SdkError<E>) -> StorageError 
             .map(|se| se.to_string())
             .unwrap_or_else(|| e.to_string())
     ))
+}
+
+#[derive(Deserialize, Debug)]
+struct ChainIdResponse {
+    result: String, // This will be a hex string like "0x1"
+}
+
+async fn get_chain_id(rpc_url: &str) -> Result<u64, StorageError> {
+    let client = reqwest::Client::new();
+
+    let request_body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_chainId",
+        "params": []
+    });
+
+    let response: ChainIdResponse = client
+        .post(rpc_url)
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|e| StorageError::Internal(format!("Failed to send RPC request: {e}")))?
+        .json()
+        .await
+        .map_err(|e| StorageError::Internal(format!("Failed to parse RPC response: {e}")))?;
+
+    // Parse hex string (e.g., "0x1") to u64
+    let chain_id = u64::from_str_radix(response.result.trim_start_matches("0x"), 16)
+        .expect("Failed to parse chain ID");
+
+    println!("Chain ID: {}", chain_id);
+
+    Ok(chain_id)
 }

--- a/crates/shielder-scheduler-server/src/storage/dynamo_db.rs
+++ b/crates/shielder-scheduler-server/src/storage/dynamo_db.rs
@@ -11,6 +11,7 @@ use aws_sdk_dynamodb::{
 };
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use tracing::info;
 
 use crate::storage::{RequestStatus, ScheduledRequest, StorageError, StorageInterface};
 
@@ -128,7 +129,16 @@ impl DynamoDb {
         }
 
         // Wait for table + GSIs to become ACTIVE
-        for _ in 0..CHECK_ACTIVE_MAX_ATTEMPTS {
+        info!(
+            "Waiting for DynamoDB table {} to become ACTIVE",
+            self.table_name
+        );
+        for attempt in 0..CHECK_ACTIVE_MAX_ATTEMPTS {
+            info!(
+                "Check attempt {}/{}",
+                attempt + 1,
+                CHECK_ACTIVE_MAX_ATTEMPTS
+            );
             let desc = self
                 .client
                 .describe_table()
@@ -145,6 +155,7 @@ impl DynamoDb {
                     .all(|g| matches!(g.index_status(), Some(IndexStatus::Active)));
 
                 if table_ready && gsis_ready {
+                    info!("DynamoDB table and GSIs are ACTIVE");
                     return Ok(());
                 }
             }
@@ -386,11 +397,8 @@ async fn get_chain_id(rpc_url: &str) -> Result<u64, StorageError> {
         .await
         .map_err(|e| StorageError::Internal(format!("Failed to parse RPC response: {e}")))?;
 
-    // Parse hex string (e.g., "0x1") to u64
     let chain_id = u64::from_str_radix(response.result.trim_start_matches("0x"), 16)
         .map_err(|e| StorageError::Internal(format!("Failed to parse chain ID: {e}")))?;
-
-    println!("Chain ID: {}", chain_id);
 
     Ok(chain_id)
 }

--- a/crates/shielder-scheduler-server/src/storage/dynamo_db.rs
+++ b/crates/shielder-scheduler-server/src/storage/dynamo_db.rs
@@ -1,9 +1,11 @@
+use std::time::Duration;
+
 use aws_sdk_dynamodb::{
     error::SdkError,
     operation::describe_table::DescribeTableError,
     types::{
-        AttributeDefinition, AttributeValue, BillingMode, GlobalSecondaryIndex, KeySchemaElement,
-        KeyType, Projection, ProjectionType, ScalarAttributeType,
+        AttributeDefinition, AttributeValue, BillingMode, GlobalSecondaryIndex, IndexStatus,
+        KeySchemaElement, KeyType, Projection, ProjectionType, ScalarAttributeType, TableStatus,
     },
     Client,
 };
@@ -11,6 +13,9 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::storage::{RequestStatus, ScheduledRequest, StorageError, StorageInterface};
+
+const CHECK_ACTIVE_MAX_ATTEMPTS: usize = 10;
+const CHECK_ACTIVE_ATTEMPT_SLEEP_DURATION: Duration = Duration::from_secs(6);
 
 pub struct DynamoDb {
     client: Client,
@@ -122,7 +127,33 @@ impl DynamoDb {
             )));
         }
 
-        Ok(())
+        // Wait for table + GSIs to become ACTIVE
+        for _ in 0..CHECK_ACTIVE_MAX_ATTEMPTS {
+            let desc = self
+                .client
+                .describe_table()
+                .table_name(&self.table_name)
+                .send()
+                .await
+                .map_err(|e| map_internal("describe_table(wait)", e))?;
+
+            if let Some(table) = desc.table() {
+                let table_ready = matches!(table.table_status(), Some(TableStatus::Active));
+                let gsis_ready = table
+                    .global_secondary_indexes()
+                    .iter()
+                    .all(|g| matches!(g.index_status(), Some(IndexStatus::Active)));
+
+                if table_ready && gsis_ready {
+                    return Ok(());
+                }
+            }
+            tokio::time::sleep(CHECK_ACTIVE_ATTEMPT_SLEEP_DURATION).await;
+        }
+
+        Err(StorageError::Internal(
+            "Timed out waiting for DynamoDB table / GSIs to become ACTIVE".into(),
+        ))
     }
 
     async fn get_item_by_last_note_index(
@@ -265,6 +296,7 @@ impl StorageInterface for DynamoDb {
         &self,
         last_note_index: &str,
         status: RequestStatus,
+        processed_at: Option<DateTime<Utc>>,
         error_message: Option<&str>,
     ) -> Result<(), StorageError> {
         let Some(mut existing) = self.get_item_by_last_note_index(last_note_index).await? else {
@@ -272,7 +304,7 @@ impl StorageInterface for DynamoDb {
         };
         existing.status = status;
         existing.error_message = error_message.map(|s| s.to_string());
-        existing.processed_at = Some(Utc::now());
+        existing.processed_at = processed_at;
 
         // Simple put since last_note_index (primary key) doesn't change
         self.put_request(&existing, None).await
@@ -283,6 +315,7 @@ impl StorageInterface for DynamoDb {
         last_note_index: &str,
         new_relay_after: DateTime<Utc>,
         new_retry_count: i32,
+        processed_at: Option<DateTime<Utc>>,
         new_error_message: Option<&str>,
     ) -> Result<(), StorageError> {
         let Some(mut existing) = self.get_item_by_last_note_index(last_note_index).await? else {
@@ -291,6 +324,7 @@ impl StorageInterface for DynamoDb {
         existing.relay_after = new_relay_after;
         existing.retry_count = new_retry_count;
         existing.error_message = new_error_message.map(|s| s.to_string());
+        existing.processed_at = processed_at;
 
         // Simple put since last_note_index (primary key) doesn't change
         self.put_request(&existing, None).await
@@ -354,7 +388,7 @@ async fn get_chain_id(rpc_url: &str) -> Result<u64, StorageError> {
 
     // Parse hex string (e.g., "0x1") to u64
     let chain_id = u64::from_str_radix(response.result.trim_start_matches("0x"), 16)
-        .expect("Failed to parse chain ID");
+        .map_err(|e| StorageError::Internal(format!("Failed to parse chain ID: {e}")))?;
 
     println!("Chain ID: {}", chain_id);
 

--- a/crates/shielder-scheduler-server/src/storage/in_memory.rs
+++ b/crates/shielder-scheduler-server/src/storage/in_memory.rs
@@ -51,11 +51,13 @@ impl StorageInterface for InMemoryStorage {
         &self,
         last_note_index: &str,
         status: RequestStatus,
+        processed_at: Option<DateTime<Utc>>,
         error_message: Option<&str>,
     ) -> Result<(), StorageError> {
         let mut requests = self.requests.lock().unwrap();
         if let Some(request) = requests.get_mut(last_note_index) {
             request.status = status;
+            request.processed_at = processed_at;
             request.error_message = error_message.map(|s| s.to_string());
             Ok(())
         } else {
@@ -68,12 +70,14 @@ impl StorageInterface for InMemoryStorage {
         last_note_index: &str,
         new_relay_after: DateTime<Utc>,
         new_retry_count: i32,
+        processed_at: Option<DateTime<Utc>>,
         new_error_message: Option<&str>,
     ) -> Result<(), StorageError> {
         let mut requests = self.requests.lock().unwrap();
         if let Some(request) = requests.get_mut(last_note_index) {
             request.relay_after = new_relay_after;
             request.retry_count = new_retry_count;
+            request.processed_at = processed_at;
             request.error_message = new_error_message.map(|s| s.to_string());
             Ok(())
         } else {

--- a/crates/shielder-scheduler-server/src/storage/in_memory.rs
+++ b/crates/shielder-scheduler-server/src/storage/in_memory.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
+use alloy_primitives::U256;
 use chrono::{DateTime, Utc};
 
 use crate::storage::{RequestStatus, ScheduledRequest, StorageError, StorageInterface};
 
 pub struct InMemoryStorage {
-    requests: std::sync::Mutex<HashMap<u128, ScheduledRequest>>,
+    requests: std::sync::Mutex<HashMap<String, ScheduledRequest>>,
 }
 
 impl InMemoryStorage {
@@ -25,8 +26,7 @@ impl StorageInterface for InMemoryStorage {
         let mut pending_requests: Vec<ScheduledRequest> = requests
             .iter()
             .filter(|(_, req)| {
-                (req.status == RequestStatus::Pending || req.status == RequestStatus::Processing)
-                    && req.relay_after <= Utc::now()
+                (req.status == RequestStatus::Pending) && req.relay_after <= Utc::now()
             })
             .map(|(_, req)| req.clone())
             .collect();
@@ -39,44 +39,45 @@ impl StorageInterface for InMemoryStorage {
         request: ScheduledRequest,
     ) -> Result<(), StorageError> {
         let mut requests = self.requests.lock().unwrap();
-        if requests.contains_key(&request.id) {
-            return Err(StorageError::DuplicateEntry(request.id));
+        let key = request.last_note_index.to_string();
+        if requests.contains_key(&key) {
+            return Err(StorageError::DuplicateEntry(key));
         }
-        requests.insert(request.id, request);
+        requests.insert(key, request);
         Ok(())
     }
 
     async fn update_request_status(
         &self,
-        id: u128,
+        last_note_index: &str,
         status: RequestStatus,
         error_message: Option<&str>,
     ) -> Result<(), StorageError> {
         let mut requests = self.requests.lock().unwrap();
-        if let Some(request) = requests.get_mut(&id) {
+        if let Some(request) = requests.get_mut(last_note_index) {
             request.status = status;
             request.error_message = error_message.map(|s| s.to_string());
             Ok(())
         } else {
-            Err(StorageError::NotFound(id.to_string()))
+            Err(StorageError::NotFound(last_note_index.to_string()))
         }
     }
 
     async fn update_retry_attempt(
         &self,
-        id: u128,
+        last_note_index: &str,
         new_relay_after: DateTime<Utc>,
         new_retry_count: i32,
         new_error_message: Option<&str>,
     ) -> Result<(), StorageError> {
         let mut requests = self.requests.lock().unwrap();
-        if let Some(request) = requests.get_mut(&id) {
+        if let Some(request) = requests.get_mut(last_note_index) {
             request.relay_after = new_relay_after;
             request.retry_count = new_retry_count;
             request.error_message = new_error_message.map(|s| s.to_string());
             Ok(())
         } else {
-            Err(StorageError::NotFound(id.to_string()))
+            Err(StorageError::NotFound(last_note_index.to_string()))
         }
     }
 
@@ -85,19 +86,6 @@ impl StorageInterface for InMemoryStorage {
         last_note_index: &str,
     ) -> Result<Option<ScheduledRequest>, StorageError> {
         let requests = self.requests.lock().unwrap();
-        let matching_requests: Vec<&ScheduledRequest> = requests
-            .iter()
-            .filter(|(_, req)| req.last_note_index.to_string() == last_note_index)
-            .map(|(_, req)| req)
-            .collect();
-
-        if let Some(earliest_request) = matching_requests
-            .into_iter()
-            .min_by(|a, b| a.created_at.cmp(&b.created_at))
-        {
-            Ok(Some(earliest_request.clone()))
-        } else {
-            Ok(None)
-        }
+        Ok(requests.get(last_note_index).cloned())
     }
 }

--- a/crates/shielder-scheduler-server/src/storage/mod.rs
+++ b/crates/shielder-scheduler-server/src/storage/mod.rs
@@ -9,8 +9,8 @@ pub mod in_memory;
 pub enum StorageError {
     #[error("Not found: {0}")]
     NotFound(String),
-    #[error("Duplicate entry. ID: {0}")]
-    DuplicateEntry(u128),
+    #[error("Duplicate entry. Last note index: {0}")]
+    DuplicateEntry(String),
     #[error("Internal error: {0}")]
     Internal(String),
 }
@@ -35,7 +35,7 @@ pub trait StorageInterface: Send + Sync {
     /// Optionally, an error message can be provided.
     async fn update_request_status(
         &self,
-        id: u128,
+        last_note_index: &str,
         status: RequestStatus,
         error_message: Option<&str>,
     ) -> Result<(), StorageError>;
@@ -45,7 +45,7 @@ pub trait StorageInterface: Send + Sync {
     /// If the request does not exist, returns a `NotFound` error.
     async fn update_retry_attempt(
         &self,
-        id: u128,
+        last_note_index: &str,
         new_relay_after: DateTime<Utc>,
         new_retry_count: i32,
         new_error_message: Option<&str>,

--- a/crates/shielder-scheduler-server/src/storage/mod.rs
+++ b/crates/shielder-scheduler-server/src/storage/mod.rs
@@ -37,6 +37,7 @@ pub trait StorageInterface: Send + Sync {
         &self,
         last_note_index: &str,
         status: RequestStatus,
+        processed_at: Option<DateTime<Utc>>,
         error_message: Option<&str>,
     ) -> Result<(), StorageError>;
 
@@ -48,6 +49,7 @@ pub trait StorageInterface: Send + Sync {
         last_note_index: &str,
         new_relay_after: DateTime<Utc>,
         new_retry_count: i32,
+        processed_at: Option<DateTime<Utc>>,
         new_error_message: Option<&str>,
     ) -> Result<(), StorageError>;
 

--- a/crates/shielder-scheduler-server/src/storage/schema.rs
+++ b/crates/shielder-scheduler-server/src/storage/schema.rs
@@ -2,11 +2,9 @@ use alloy_primitives::{Address, U256};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use shielder_scheduler_common::protocol::EncryptionEnvelope;
-use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheduledRequest {
-    pub id: u128,
     pub encryption_envelope: EncryptionEnvelope,
     pub last_note_index: U256,
     pub pocket_money: U256,
@@ -27,9 +25,7 @@ impl ScheduledRequest {
         token_address: Address,
         relay_after: DateTime<Utc>,
     ) -> Self {
-        let id = Uuid::new_v4().as_u128();
         Self {
-            id,
             encryption_envelope,
             last_note_index,
             pocket_money,
@@ -48,7 +44,6 @@ impl ScheduledRequest {
 #[serde(rename_all = "lowercase")]
 pub enum RequestStatus {
     Pending,
-    Processing,
     Completed,
     Failed,
 }


### PR DESCRIPTION
This pull request introduces significant changes to how scheduled withdraw requests are identified and stored in the scheduler server, transitioning from using a UUID-based `id` to using `last_note_index` as the primary identifier. The DynamoDB schema and related logic have been updated to support this change, and all references to request IDs throughout the codebase have been replaced accordingly. Additionally, the DynamoDB table is now dynamically named based on the chain ID, and a global secondary index (GSI) has been added to improve query efficiency.

**Database schema and storage logic updates:**

* The DynamoDB table schema now uses `last_note_index` as the primary key instead of `id`, and the table name is dynamically generated based on the chain ID. A global secondary index (`StatusRelayAfterIndex`) on `status` and `relay_after` has been added for more efficient queries. The billing mode is set to pay-per-request.
* All methods in the DynamoDB storage implementation (`dynamo_db.rs`) have been refactored to use `last_note_index` for item retrieval and updates, replacing previous references to `id`. 

**Codebase-wide identifier changes:**

* All references to request identification throughout the scheduler server codebase have been updated to use `last_note_index` instead of `id`, including logging, API responses, and status updates.

**Dependency cleanup:**

* The unused `uuid` dependency has been removed from both the root `Cargo.toml` and the scheduler server crate's `Cargo.toml`, reflecting the shift away from UUIDs for request identification.

**Configuration improvements:**

* The DynamoDB storage initialization now requires the node RPC URL to determine the chain ID, ensuring that the correct table is used for each blockchain network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - Logs, API responses and storage now use last_note_index (string) instead of numeric id; "Processing" status removed (Pending, Completed, Failed only).
  - Storage keys and error messages now reference string last_note_index.

- Operations
  - Non-local deployments require a node RPC URL; storage resolves chain ID and uses dynamic DynamoDB table names.

- Documentation
  - Database Schema and API Testing sections removed from the README.

- Chores
  - Removed uuid dependency from the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->