### PR TITLE
BAC-255: Disable nightly

### DIFF
--- a/.github/workflows/testnet-nightly-e2e.yml
+++ b/.github/workflows/testnet-nightly-e2e.yml
@@ -1,6 +1,7 @@
 # This workflow is out-to-date. It won't work as it is now, due to the fact Base Sepolia testnet 
 # has a specific behaviour resulting in errors like "replacement transaction underpriced" or "nonce too low:".
-# current workaround was to sleep, but it was removed in https://github.com/Cardinal-Cryptography/blanksquare-monorepo/commit/72536953ee7d324b4a776c0726ae035bace88655#diff-3df7cd0db2829cdf3b5197063ca9550661d58f7b6316e5eec8bf95aa779b016c
+# current workaround was to sleep, but it was removed in 
+# https://github.com/Cardinal-Cryptography/blanksquare-monorepo/commit/72536953ee7d324b4a776c0726ae035bace88655
 ---
 name: Nightly E2E tests run on testnet
 

--- a/.github/workflows/testnet-nightly-e2e.yml
+++ b/.github/workflows/testnet-nightly-e2e.yml
@@ -1,9 +1,10 @@
+# This workflow is out-to-date. It won't work as it is now, due to the fact Base Sepolia testnet 
+# has a specific behaviour resulting in errors like "replacement transaction underpriced" or "nonce too low:".
+# current workaround was to sleep, but it was removed in https://github.com/Cardinal-Cryptography/blanksquare-monorepo/commit/72536953ee7d324b4a776c0726ae035bace88655#diff-3df7cd0db2829cdf3b5197063ca9550661d58f7b6316e5eec8bf95aa779b016c
 ---
 name: Nightly E2E tests run on testnet
 
 on:
-  schedule:
-    - cron: "00 23 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to disable automatic scheduled execution for testnet end-to-end testing; workflow now requires manual triggering only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->